### PR TITLE
Update Epi25 Browser per comments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.13.1-alpine AS build
+FROM --platform=linux/amd64 node:16.13.1-alpine AS build
 
 RUN mkdir -p /home/node/app && chown -R node:node /home/node/app
 WORKDIR /home/node/app
@@ -22,7 +22,7 @@ COPY --chown=node:node build.env .
 RUN export $(cat build.env | xargs); yarn run build
 
 ###############################################################################
-FROM node:16.13.1-alpine
+FROM --platform=linux/amd64 node:16.13.1-alpine
 
 RUN mkdir -p /home/node/app && chown -R node:node /home/node/app
 WORKDIR /home/node/app

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -72,12 +72,13 @@ the browsers and so cannot be attached to another instance in read-write mode.
    apt-get -qq install adoptopenjdk-8-hotspot
    apt-get -qq install python3-pip
    pip3 install hail
+   pip3 install tqdm
    ```
 
 6. Copy results data from GCS.
 
    ```
-   gsutil -q cp -r gs://exome-results-browsers/data/combined.ht /tmp
+   gsutil -q cp -r gs://exome-results-browsers/data/<DATA-DATE>/combined.ht /tmp
    ```
 
 7. Write results files to persistent disk.
@@ -122,6 +123,22 @@ Build the Docker image. The build script tags the image with the current git rev
 ```
 ./deployment/build-docker-image.sh
 ```
+
+## Updating Production Deployment
+
+Build the Docker image. When the Docker image is finished building, the script prints the name and tag to the console
+
+```
+./deployment/build-docker-image.sh
+```
+
+Update the production deployment to the desired Docker image with
+
+```
+./deployment/deploy-image.sh <IMAGE-TAG>
+```
+
+To update both the production front/backend and the data at the same time, modify the `pdName` value in the volumes section of `deployment/manifests/deployment.yaml` before running the `deploy-image` script.
 
 ## GKE resources
 

--- a/src/browsers/epi25/Epi25Browser.js
+++ b/src/browsers/epi25/Epi25Browser.js
@@ -75,13 +75,13 @@ const Epi25Browser = () => (
       {
         key: 'damaging_missense_case_count',
         heading: 'Damaging Missense Case Count',
-        minWidth: 70,
+        minWidth: 85,
         render: renderCount,
       },
       {
         key: 'damaging_missense_control_count',
         heading: 'Damaging Missense Control Count',
-        minWidth: 70,
+        minWidth: 85,
         render: renderCount,
       },
       {
@@ -143,6 +143,11 @@ const Epi25Browser = () => (
       {
         term: 'ptv',
         label: 'Protein-truncating',
+        category: 'lof',
+      },
+      {
+        term: 'pLoF',
+        label: 'Probably Loss-of-Function',
         category: 'lof',
       },
       {

--- a/src/browsers/epi25/Epi25GeneResults.js
+++ b/src/browsers/epi25/Epi25GeneResults.js
@@ -23,6 +23,16 @@ const renderOddsRatio = (value) => {
   return value.toPrecision(3)
 }
 
+const renderPVal = (pval) => {
+  if (pval === null) {
+    return '-'
+  }
+  if (pval === 0) {
+    return '2.2e-16'
+  }
+  return pval.toPrecision(3)
+}
+
 const Epi25GeneResult = ({ result }) => (
   <div>
     <Table>
@@ -40,7 +50,7 @@ const Epi25GeneResult = ({ result }) => (
           <th scope="row">Protein-truncating</th>
           <td>{result.ptv_case_count === null ? '-' : result.ptv_case_count}</td>
           <td>{result.ptv_control_count === null ? '-' : result.ptv_control_count}</td>
-          <td>{result.ptv_pval === null ? '-' : result.ptv_pval.toPrecision(3)}</td>
+          <td>{renderPVal(result.ptv_pval)}</td>
           <td>{renderOddsRatio(result.ptv_OR)}</td>
         </tr>
         <tr>
@@ -55,11 +65,7 @@ const Epi25GeneResult = ({ result }) => (
               ? '-'
               : result.damaging_missense_control_count}
           </td>
-          <td>
-            {result.damaging_missense_pval === null
-              ? '-'
-              : result.damaging_missense_pval.toPrecision(3)}
-          </td>
+          <td>{renderPVal(result.damaging_missense_pval)}</td>
           <td>{renderOddsRatio(result.damaging_missense_OR)}</td>
         </tr>
       </tbody>
@@ -110,7 +116,7 @@ const Epi25GeneResults = ({ results }) => (
               level. The burden of ultra-rare, deleterious SNVs and indels - protein-truncating or
               damaging missense (with an MPC score&le;2) variants - in cases versus controls is
               assessed using a Firth logistic regression test with adjustment for sex and genetic
-              ancestry.
+              ancestry (P-value is capped at 2.2e-16).
             </p>
           </>
         }

--- a/src/browsers/epi25/Epi25HomePage.js
+++ b/src/browsers/epi25/Epi25HomePage.js
@@ -81,7 +81,7 @@ const Epi25HomePage = () => (
       <Link to="/downloads">available for download</Link>.
     </p>
 
-    <p>Analysis data last updated November January 23, 2023.</p>
+    <p>Analysis data last updated January 23, 2023.</p>
   </HomePageWrapper>
 )
 


### PR DESCRIPTION
Fixes typo in home page of Epi25 dataset.

Updates the display of pvalues of 0 to the resolution of the analysis package (2.2e-16) and the display of pLoF in the variant table to correctly show a red consequence dot, and the full Probably Loss-of-Function text instead of the pLoF acronym, per Siwei's comments.

---

Updates Dockerfile for arm64 machines (Mac M1s).

Updates deployment readme to document the existence of the `deploy-image.sh` script.

---

Related: #68, https://github.com/broadinstitute/gnomad-browser-team/issues/30