### PR TITLE
Modify Epi25 pLoF label to Protein-truncating

### DIFF
--- a/src/browsers/epi25/Epi25Browser.js
+++ b/src/browsers/epi25/Epi25Browser.js
@@ -141,13 +141,8 @@ const Epi25Browser = () => (
         category: 'missense',
       },
       {
-        term: 'ptv',
-        label: 'Protein-truncating',
-        category: 'lof',
-      },
-      {
         term: 'pLoF',
-        label: 'Probably Loss-of-Function',
+        label: 'Protein-truncating',
         category: 'lof',
       },
       {


### PR DESCRIPTION
Related: #68, https://github.com/broadinstitute/gnomad-browser-team/issues/30

Minor update to Epi25 to the browser display in the variant table to say Protein-truncating instead of Probably Loss-of-Function.

I realize many tiny commits like this is not ideal, I had misunderstood one of the comments, and this has resulted in these short PRs to fix things as they are noticed/commented on/cleared up.

![Screenshot 2023-01-25 at 13 15 36](https://user-images.githubusercontent.com/59549713/214665022-8d661445-ff24-4b25-b704-da754dae638f.jpg)
