### PR TITLE
Update Epi25 contact

### DIFF
--- a/src/browsers/epi25/Epi25HomePage.js
+++ b/src/browsers/epi25/Epi25HomePage.js
@@ -72,8 +72,8 @@ const Epi25HomePage = () => (
       <ExternalLink href="https://epi-25.org/epi25-members/">consortium members</ExternalLink> and
       patients for their gracious contribution to make this collaboration possible. We welcome any
       feedback! You can contact us by{' '}
-      <ExternalLink href="mailto:yfeng@broadinstitute.org">email</ExternalLink> if you have any
-      questions or suggestions.
+      <ExternalLink href="mailto:epi25browser@broadinstitute.org">email</ExternalLink> if you have
+      any questions or suggestions.
     </p>
 
     <p>


### PR DESCRIPTION
Quick 1 line change.

Updates the contact email on the Epi25 home page to the newly created google group for the Epi25 browser (epi25browser@broadinstitute.org).