### PR TITLE
Update link to Epi25 paper preprint

### DIFF
--- a/src/browsers/epi25/Epi25HomePage.js
+++ b/src/browsers/epi25/Epi25HomePage.js
@@ -60,9 +60,13 @@ const Epi25HomePage = () => (
       factors. Integrating these findings with associations implicated by copy number variants
       (CNVs) and genome-wide association study (GWAS), we further identified convergence of
       different types of genetic risk factor in the same genes. Details of the WES analyses as well
-      as the variant-calling and QC pipelines can be found in our latest preprint on bioRxiv. With
-      the continuing effort to recruit samples, many from non-European populations, we anticipate a
-      boost in the detection power to identify risk-conferring genes in the coming years.
+      as the variant-calling and QC pipelines can be found in our latest{' '}
+      <ExternalLink href="https://www.medrxiv.org/content/10.1101/2023.02.22.23286310">
+        preprint on medRxiv
+      </ExternalLink>
+      . With the continuing effort to recruit samples, many from non-European populations, we
+      anticipate a boost in the detection power to identify risk-conferring genes in the coming
+      years.
     </p>
 
     <p>


### PR DESCRIPTION
A quick one line change to update the text / hyperlink on the Epi25 homepage now that the latest preprint is live on medRxiv.