### PR TITLE
update deployment values for new cluster

### DIFF
--- a/deployment/manifests/deployment.yaml
+++ b/deployment/manifests/deployment.yaml
@@ -46,5 +46,5 @@ spec:
         - name: data
           gcePersistentDisk:
             fsType: ext4
-            pdName: exome-results-browsers-data-230123-1052
+            pdName: exome-results-browsers-data-230123-1052-east1c
             readOnly: true

--- a/deployment/manifests/ingress.yaml
+++ b/deployment/manifests/ingress.yaml
@@ -4,7 +4,7 @@ kind: Ingress
 metadata:
   name: exome-results-browsers-ingress
   annotations:
-    kubernetes.io/ingress.global-static-ip-name: exome-results-browsers
+    kubernetes.io/ingress.global-static-ip-name: prod-exome-results-browsers-ip
     ingress.gcp.kubernetes.io/pre-shared-cert: exome-results-browsers-cert
     networking.gke.io/v1beta1.FrontendConfig: exome-results-browsers-frontend-config
   labels:


### PR DESCRIPTION
This makes a few small adjustments to the exome-results-browsers deployment to match new IP names, etc on the new infrastructure.