### PR TITLE
Allow single source dataset updates and fully local development

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
       - name: Use yarn cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: yarn-${{ hashFiles('**/yarn.lock') }}
@@ -44,7 +44,7 @@ jobs:
         with:
           python-version: 3.9.17
       - name: Use pip cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: pip-${{ hashFiles('**/requirements*.txt') }}

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ __pycache__
 
 # Hail logs
 hail-*.log
+
+# dev data
+/data

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,5 +44,8 @@ COPY --chown=node:node --from=build /home/node/app/src/server/public ./public
 # Copy server source
 COPY --chown=node:node src/server .
 
+# Copy build environment variables
+COPY --chown=node:node build.env .
+
 # Run
-CMD ["node", "server.js"]
+CMD export "$(xargs < build.env)"; node server.js

--- a/data_pipeline/data_pipeline/datasets/epi25/epi25_gene_results.py
+++ b/data_pipeline/data_pipeline/datasets/epi25/epi25_gene_results.py
@@ -3,8 +3,17 @@ import hail as hl
 from data_pipeline.config import pipeline_config
 
 
-def prepare_gene_results():
+def filter_results_table_to_test_gene(results, test_gene_symbol):
+    results = results.filter(results.gene_symbol == test_gene_symbol)
+
+    return results.persist()
+
+
+def prepare_gene_results(test_gene_id):
     results = hl.read_table(pipeline_config.get("Epi25", "gene_results_path"))
+
+    if test_gene_id:
+        results = filter_results_table_to_test_gene(results, test_gene_id)
 
     results = results.select_globals()
 

--- a/data_pipeline/data_pipeline/datasets/epi25/epi25_variant_results.py
+++ b/data_pipeline/data_pipeline/datasets/epi25/epi25_variant_results.py
@@ -3,8 +3,26 @@ import hail as hl
 from data_pipeline.config import pipeline_config
 
 
-def prepare_variant_results():
+def filter_results_table_to_test_gene_interval(results, test_gene_symbol):
+
+    if test_gene_symbol != "PCSK9":
+        print("Genes other than PCSK9 not yet supported")
+        exit(1)
+
+    test_gene_locus_interval = hl.locus_interval(
+        "chr1", 55039447, 55064852, reference_genome="GRCh38", includes_start=True, includes_end=True
+    )
+
+    results = hl.filter_intervals(results, [test_gene_locus_interval])
+
+    return results
+
+
+def prepare_variant_results(test_gene_id):
     results = hl.read_table(pipeline_config.get("Epi25", "variant_results_path"))
+
+    if test_gene_id:
+        results = filter_results_table_to_test_gene_interval(results, test_gene_id)
 
     # Get unique variants from results table
     variants = results.group_by(results.locus, results.alleles).aggregate()

--- a/data_pipeline/data_pipeline/pipelines/prepare_datasets.py
+++ b/data_pipeline/data_pipeline/pipelines/prepare_datasets.py
@@ -9,22 +9,33 @@ from data_pipeline.config import pipeline_config
 from data_pipeline.validation import validate_gene_results_table, validate_variant_results_table
 
 
-def prepare_dataset(dataset_id):
+def get_output_root(output_local):
+    output_location = "local" if output_local else "gcs"
+    output_root = pipeline_config.get("output", f"{output_location}_output_root")
+
+    if output_local:
+        script_dir = os.path.dirname(os.path.abspath(__file__))
+        output_root = os.path.abspath(os.path.join(script_dir, "..", "..", "..", output_root))
+
+    return output_root
+
+
+def prepare_dataset(dataset_id, test_gene_symbol, output_local):
     update_date = pipeline_config.get(dataset_id, "output_last_updated")
-    output_root = pipeline_config.get("output", "gcs_output_root")
+    output_root = get_output_root(output_local)
     output_path = f"{output_root}/{dataset_id.lower()}/{update_date}"
 
     gene_results_module = importlib.import_module(
         f"data_pipeline.datasets.{dataset_id.lower()}.{dataset_id.lower()}_gene_results"
     )
-    gene_results = gene_results_module.prepare_gene_results()
+    gene_results = gene_results_module.prepare_gene_results(test_gene_symbol)
     validate_gene_results_table(gene_results)
     gene_results.write(os.path.join(output_path, "gene_results.ht"), overwrite=True)
 
     variant_results_module = importlib.import_module(
         f"data_pipeline.datasets.{dataset_id.lower()}.{dataset_id.lower()}_variant_results"
     )
-    variant_results = variant_results_module.prepare_variant_results()
+    variant_results = variant_results_module.prepare_variant_results(test_gene_symbol)
     validate_variant_results_table(variant_results)
     variant_results.write(os.path.join(output_path, "variant_results.ht"), overwrite=True)
 
@@ -38,6 +49,15 @@ def main():
         metavar=f"{{{','.join(all_datasets)}}}",
         required=True,
         help=f"Datasets to process. Either 'all', or a space separated list of {', '.join(all_datasets)}",
+    )
+
+    parser.add_argument("--output-local", action="store_true", help="Output files locally instead of to cloud storage")
+
+    parser.add_argument(
+        "--test-gene",
+        nargs="?",
+        const="PCSK9",
+        default=None,
     )
 
     args = parser.parse_args()
@@ -55,7 +75,7 @@ def main():
     hl.init()
 
     for dataset in datasets_to_prepare:
-        prepare_dataset(dataset)
+        prepare_dataset(dataset, args.test_gene, args.output_local)
 
 
 if __name__ == "__main__":

--- a/data_pipeline/data_pipeline/pipelines/prepare_gene_models.py
+++ b/data_pipeline/data_pipeline/pipelines/prepare_gene_models.py
@@ -1,3 +1,6 @@
+import os
+import sys
+
 import hail as hl
 
 from data_pipeline.config import pipeline_config
@@ -249,12 +252,17 @@ def prepare_gene_models():
     exac_constraint = prepare_exac_constraint(exac_constraint_path)
     genes = genes.annotate(exac_constraint=exac_constraint[genes.GRCh37.canonical_transcript_id])
 
-    staging_path = pipeline_config.get("output", "staging_path")
+    output_date = pipeline_config.get("reference_data", "output_last_updated")
+    output_root = pipeline_config.get("output", "gcs_output_root")
+    output_path = os.path.join(output_root, "gene_models", output_date, "gene_models.ht")
 
-    genes.write(f"{staging_path}/gene_models.ht", overwrite=True)
+    genes.write(output_path, overwrite=True)
+
+
+def main():
+    hl.init()
+    prepare_gene_models()
 
 
 if __name__ == "__main__":
-    hl.init()
-
-    prepare_gene_models()
+    sys.exit(main())

--- a/data_pipeline/pipeline_config.ini
+++ b/data_pipeline/pipeline_config.ini
@@ -62,5 +62,6 @@ service-account = erb-data-pipeline@exac-gnomad.iam.gserviceaccount.com
 [output]
 # Path for intermediate Hail files.
 gcs_output_root = gs://exome-results-browsers/output-data
+local_output_root = data/output-data
 
 output_last_updated = 2025-04-01

--- a/data_pipeline/pipeline_config.ini
+++ b/data_pipeline/pipeline_config.ini
@@ -10,25 +10,35 @@ dbs_variant_annotations_path = gs://asc-browser/DBS_variant_annotation_table_201
 swe_variant_results_path = gs://asc-browser/SWE_variant_results_table_2019-04-16.tsv.gz
 swe_variant_annotations_path = gs://asc-browser/SWE_variant_annotation_table_2019-04-16.tsv.gz
 
+output_last_updated = 2019-05-16
+
 [BipEx]
 gene_results_path = gs://bipex-browser/220107/browser_gene_results_table_jan_2022.ht
 variant_results_path = gs://bipex-browser/220107/browser_variant_results_table_jan_2022.ht
 variant_annotations_path = gs://bipex-browser/200421/browser_variant_annotation_table.ht
+
+output_last_updated = 2022-02-07
 
 [Epi25]
 gene_results_path = gs://epi25/year5/browser_files/202212/browser_gene_results_table.ht
 variant_results_path = gs://epi25/year5/browser_files/202212/browser_variant_results_table.ht
 variant_annotations_path = gs://epi25/year5/browser_files/202212/browser_variant_annotation_table.ht
 
+output_last_updated = 2023-01-01
+
 [SCHEMA]
 gene_results_path = gs://schema-browser/200831/schema-results-table-supplement.tsv
 variant_results_path = gs://schema-browser/200911/2020-09-11_schema-browser-variant-results-table-meta-rare-denovos-common-merged.ht
 variant_annotations_path = gs://schema-browser/200911/2020-09-11_schema-browser-variant-annotation-table.ht
 
+output_last_updated = 2020-10-11
+
 [IBD]
-gene_results_path = gs://ibd-browser/09-11-2023/gene_based_results.ht 
-variant_results_path = gs://ibd-browser/09-11-2023/variants_results.ht 
-variant_annotations_path = gs://ibd-browser/09-11-2023/variants_annotations.ht 
+gene_results_path = gs://ibd-browser/09-11-2023/gene_based_results.ht
+variant_results_path = gs://ibd-browser/09-11-2023/variants_results.ht
+variant_annotations_path = gs://ibd-browser/09-11-2023/variants_annotations.ht
+
+output_last_updated = 2023-10-11
 
 [reference_data]
 grch37_gencode_path = gs://exome-results-browsers/reference/gencode.v19.gtf.bgz
@@ -40,6 +50,8 @@ hgnc_path = gs://exome-results-browsers/reference/hgnc.tsv
 gnomad_constraint_path = gs://gcp-public-data--gnomad/release/2.1.1/constraint/gnomad.v2.1.1.lof_metrics.by_transcript.ht
 exac_constraint_path = gs://gcp-public-data--gnomad/legacy/exac_browser/forweb_cleaned_exac_r03_march16_z_data_pLI_CNV-final.txt.gz
 
+output_last_updated = 2023-09-22
+
 [dataproc]
 project = exac-gnomad
 region = us-east1
@@ -49,4 +61,6 @@ service-account = erb-data-pipeline@exac-gnomad.iam.gserviceaccount.com
 
 [output]
 # Path for intermediate Hail files.
-staging_path = gs://exome-results-browsers/data/231116
+gcs_output_root = gs://exome-results-browsers/output-data
+
+output_last_updated = 2025-04-01

--- a/data_pipeline/start_dataproc_cluster.py
+++ b/data_pipeline/start_dataproc_cluster.py
@@ -8,7 +8,11 @@ import subprocess
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--dry-run", action="store_true", help="Print cluster creation command without running it")
+    parser.add_argument("cluster_args", nargs=argparse.REMAINDER)
     args = parser.parse_args()
+
+    if args.cluster_args and args.cluster_args[0] == "--":
+        args.cluster_args = args.cluster_args[1:]
 
     # Set working directory so that config.py finds pipeline_config.ini
     os.chdir(os.path.dirname(os.path.abspath(__file__)))
@@ -21,7 +25,7 @@ def main():
         "start",
         "exome-results",
         "--max-idle=1h",
-    ]
+    ] + args.cluster_args
 
     for option in ["project", "region", "zone", "service-account"]:
         value = pipeline_config.get("dataproc", option, fallback=None)

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -65,14 +65,12 @@ the browsers and so cannot be attached to another instance in read-write mode.
 5. Install Hail.
 
    ```
-   apt-get -qq install wget software-properties-common
-   wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | apt-key add -
-   add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/
-   apt-get -qq update
-   apt-get -qq install adoptopenjdk-8-hotspot
-   apt-get -qq install python3-pip
-   pip3 install hail
-   pip3 install tqdm
+   apt-get install -y \
+      openjdk-11-jre-headless \
+      g++ \
+      python3.9 python3-pip \
+      libopenblas-base liblapack3
+   python3.9 -m pip install hail
    ```
 
 6. Copy results data from GCS.

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -16,7 +16,7 @@ the browsers and so cannot be attached to another instance in read-write mode.
 
 1. Create a temporary GCE instance.
 
-   Debian 11 is used here to get a more up to date version of Python (Debian 10 is the default at the time of this writing).
+   Debian 11 is used here to have Python 3.9
 
    ```
    gcloud --quiet compute instances create erb-temp-instance \
@@ -55,6 +55,14 @@ the browsers and so cannot be attached to another instance in read-write mode.
    gcloud compute ssh erb-temp-instance
    ```
 
+   Start interactive root session
+
+   ```
+   sudo su -
+   ```
+
+
+   Format the disk, mount the disk
    ```
    mkfs.ext4 -m 0 -E lazy_itable_init=0,lazy_journal_init=0,discard /dev/disk/by-id/google-erb-data
 
@@ -64,6 +72,7 @@ the browsers and so cannot be attached to another instance in read-write mode.
 
 5. Install Hail.
 
+   Install Java 11
    ```
    apt-get install -y \
       openjdk-11-jre-headless \
@@ -73,10 +82,15 @@ the browsers and so cannot be attached to another instance in read-write mode.
    python3.9 -m pip install hail
    ```
 
+   Install Hail and tqdm. Versions should be kept in sync with requirements.txt
+   ```
+   python3.9 -m pip install hail==0.2.126 tqdm=4.66.5
+   ```
+
 6. Copy results data from GCS.
 
    ```
-   gsutil -q cp -r gs://exome-results-browsers/data/<DATA-DATE>/combined.ht /tmp
+   gsutil cp -r gs://exome-results-browsers/data/<DATA-DATE>/combined.ht /tmp
    ```
 
 7. Write results files to persistent disk.

--- a/start.sh
+++ b/start.sh
@@ -2,6 +2,32 @@
 
 set -eu
 
+# Explicitly declare what env vars we want to pull in
+#   we don't include GA Tracking IDs as that would add false traffic
+development_environment_variables=("DEMO_PASSWORD")
+
+if [ -f "build.env" ]; then
+  while IFS= read -r line; do
+    if [[ "$line" =~ ^# ]] || [[ -z "$line" ]]; then
+      continue
+    fi
+
+    var_name=$(echo "$line" | cut -d'=' -f1)
+
+    is_allowed=false
+    for allowed_var in "${development_environment_variables[@]}"; do
+      if [ "$var_name" = "$allowed_var" ]; then
+        is_allowed=true
+        break
+      fi
+    done
+
+    if "$is_allowed"; then
+      export "$line"
+    fi
+  done < "build.env"
+fi
+
 print_usage() {
   echo "Usage: start.sh BROWSER [--proxy-api] [--port PORT]" 1>&2
 }


### PR DESCRIPTION
Splits tooling/structural changes into a separate PR to rebase both the IBD and GP2 work off of.

Notably, there are:
- Tooling bumps
- Restructuring of paths defined in `config.ini` and in the pipeline code to allow for single source data updates (resolves #24, resolves #97)
- Adding to pipelines to allow for fully local dev development on a single test gene (all the way from input data to local browser running with subsetted data, without having to use dataproc)