### PR TITLE
Update GRCh38 data sources

### DIFF
--- a/data_pipeline/README.md
+++ b/data_pipeline/README.md
@@ -37,7 +37,7 @@ Configuration is divided into sections:
 
   - `grch38_gencode_path`
 
-    Copy of ftp://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/release_29/gencode.v29.annotation.gtf.gz
+    Copy of ftp://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/release_39/gencode.v39.annotation.gtf.gz
     compressed with blocked gzip.
 
   - `grch37_canonical_transcripts_path` and `grch38_canonical_transcripts_path`

--- a/data_pipeline/README.md
+++ b/data_pipeline/README.md
@@ -69,6 +69,10 @@ Configuration is divided into sections:
     Copy of the reduced GRCh38 ClinVar hail table from GeniE
     `gs://aggregate-frequency-calculator-data/ClinVar/ClinVar_GRCh38_variants.ht`
 
+  - `dbSNP_grch38_rsids_path`
+
+    Copy of the GRCh38 dbSNP rsid only hail table from Hail's datasets (`gs://hail-datasets-us-central1/..)
+
 - `output`
 
   - `staging_path` - path of the directory where pipelines should write Hail Tables

--- a/data_pipeline/data_pipeline/datasets/gp2/gp2_variant_results.py
+++ b/data_pipeline/data_pipeline/datasets/gp2/gp2_variant_results.py
@@ -94,7 +94,7 @@ def prepare_variant_results(results, annotations, test_genes, _output_root):
 
     variants = results.key_by("locus", "alleles")
 
-    # keep this in sync with GRCh38 path in config.ini
+    # keep this in sync with clinvar_grch38_path in config.ini
     clinvar_grch38_path = "gs://exome-results-browsers/reference/clinvar_grch38_variants.ht"
     clinvar = hl.read_table(clinvar_grch38_path)
     clinvar = clinvar.select(
@@ -104,11 +104,17 @@ def prepare_variant_results(results, annotations, test_genes, _output_root):
     )
     annotations = annotations.annotate(**clinvar[annotations.locus, annotations.alleles])
 
+    # keep this in sync with dbSNP_grch38_rsids_path in config.ini
+    dbSNP_grch38_path = "gs://exome-results-browsers/reference/dbSNP_grch38_rsids.ht"
+    dbSNP_rsids = hl.read_table(dbSNP_grch38_path)
+    dbSNP_rsids = dbSNP_rsids.select_globals()
+    dbSNP_rsids = dbSNP_rsids.select(
+        "rsid",
+    )
+    annotations = annotations.annotate(**dbSNP_rsids[annotations.locus, annotations.alleles])
+
     annotations = annotations.select(
         "gene_id",
-        "clinvar_variation_id",
-        "clinical_significance",
-        "clinical_significance_category",
         consequence=annotations.consequence,
         hgvsc=annotations.hgvsc.split(":")[-1],
         hgvsp=annotations.hgvsp.split(":")[-1],
@@ -117,6 +123,7 @@ def prepare_variant_results(results, annotations, test_genes, _output_root):
             clinvar_variation_id=annotations.clinvar_variation_id,
             clinical_significance=annotations.clinical_significance,
             clinical_significance_category=annotations.clinical_significance_category,
+            rsid=annotations.rsid,
         ),
     )
 

--- a/data_pipeline/data_pipeline/pipelines/prepare_gene_models.py
+++ b/data_pipeline/data_pipeline/pipelines/prepare_gene_models.py
@@ -135,11 +135,11 @@ def prepare_gene_models_helper(reference_genome):
     genes = genes.annotate(
         canonical_transcript=genes.transcripts.filter(
             lambda transcript: transcript.transcript_id == genes.canonical_transcript_id
-        ).head()
+        ).first()
     )
     genes = genes.annotate(
         canonical_transcript=genes.canonical_transcript.annotate(
-            exons=hl.cond(
+            exons=hl.if_else(
                 genes.canonical_transcript.exons.any(lambda exon: exon.feature_type == "CDS"),
                 genes.canonical_transcript.exons.filter(lambda exon: exon.feature_type == "CDS"),
                 genes.canonical_transcript.exons.filter(lambda exon: exon.feature_type == "exon"),

--- a/data_pipeline/pipeline_config.ini
+++ b/data_pipeline/pipeline_config.ini
@@ -67,6 +67,8 @@ exac_constraint_path = gs://gcp-public-data--gnomad/legacy/exac_browser/forweb_c
 clinvar_grch37_path = gs://exome-results-browsers/reference/clinvar_grch37_variants.ht
 clinvar_grch38_path = gs://exome-results-browsers/reference/clinvar_grch38_variants.ht
 
+dbSNP_grch38_rsids_path = gs://exome-results-browsers/reference/dbSNP_grch38_rsids.ht
+
 output_last_updated = 2025-09-18
 
 [dataproc]

--- a/data_pipeline/pipeline_config.ini
+++ b/data_pipeline/pipeline_config.ini
@@ -56,7 +56,8 @@ output_last_updated = 2025-09-18
 
 [reference_data]
 grch37_gencode_path = gs://exome-results-browsers/reference/gencode.v19.gtf.bgz
-grch38_gencode_path = gs://exome-results-browsers/reference/gencode.v29.gtf.bgz
+grch38_gencode_path = gs://exome-results-browsers/reference/gencode.v39.gtf.bgz
+
 grch37_canonical_transcripts_path = gs://exome-results-browsers/reference/gnomad_2.1.1_vep85_canonical_transcripts.tsv.bgz
 grch38_canonical_transcripts_path = gs://exome-results-browsers/reference/gnomad_3.0_vep95_canonical_transcripts.tsv.bgz
 hgnc_path = gs://exome-results-browsers/reference/hgnc.tsv
@@ -69,7 +70,7 @@ clinvar_grch38_path = gs://exome-results-browsers/reference/clinvar_grch38_varia
 
 dbSNP_grch38_rsids_path = gs://exome-results-browsers/reference/dbSNP_grch38_rsids.ht
 
-output_last_updated = 2025-09-18
+output_last_updated = 2025-09-19
 
 [dataproc]
 project = exac-gnomad

--- a/src/browsers/base/GenePage/VariantsInGene.js
+++ b/src/browsers/base/GenePage/VariantsInGene.js
@@ -450,6 +450,47 @@ VariantsInGene.defaultProps = {
   renderVariantTranscriptConsequences: false,
 }
 
+const addSingleAF = (args) => {
+  const { groupResult, prefix, suffix } = args
+
+  const ac = groupResult[`${prefix}ac_${suffix}`]
+  const an = groupResult[`${prefix}an_${suffix}`]
+  let af = null
+
+  if (ac === null || an === null) {
+    af = null
+  } else if (an === 0) {
+    af = 0
+  } else {
+    af = ac / an
+  }
+
+  groupResult[`${prefix}af_${suffix}`] = af
+}
+
+const addOverallAF = (args) => {
+  const { groupResult, prefix } = args
+
+  const caseAC = groupResult[`${prefix}ac_case`]
+  const caseAN = groupResult[`${prefix}an_case`]
+  const controlAC = groupResult[`${prefix}ac_ctrl`]
+  const controlAN = groupResult[`${prefix}an_ctrl`]
+  const caseAF = groupResult[`${prefix}af_case`]
+  const controlAF = groupResult[`${prefix}af_ctrl`]
+
+  let overallAF = null
+
+  if (caseAF === null || controlAF === null) {
+    overallAF = null
+  } else if (caseAN + controlAN === 0) {
+    overallAF = 0
+  } else {
+    overallAF = (caseAC + controlAC) / (caseAN + controlAN)
+  }
+
+  groupResult[`${prefix}af`] = overallAF
+}
+
 const VariantsInGeneContainer = ({
   datasetId,
   gene,
@@ -501,75 +542,17 @@ const VariantsInGeneContainer = ({
                   )
 
                   if (datasetId !== 'GP2') {
-                    if (groupResult.ac_case === null || groupResult.an_case === null) {
-                      groupResult.af_case = null
-                    } else if (groupResult.an_case === 0) {
-                      groupResult.af_case = 0
-                    } else {
-                      groupResult.af_case = groupResult.ac_case / groupResult.an_case
-                    }
-
-                    if (groupResult.ac_ctrl === null || groupResult.an_ctrl === null) {
-                      groupResult.af_ctrl = null
-                    } else if (groupResult.an_ctrl === 0) {
-                      groupResult.af_ctrl = 0
-                    } else {
-                      groupResult.af_ctrl = groupResult.ac_ctrl / groupResult.an_ctrl
-                    }
-
-                    if (groupResult.af_case === null || groupResult.af_ctrl === null) {
-                      groupResult.af = null
-                    } else if (groupResult.an_case + groupResult.an_ctrl === 0) {
-                      groupResult.af = 0
-                    } else {
-                      groupResult.af =
-                        (groupResult.ac_case + groupResult.ac_ctrl) /
-                        (groupResult.an_case + groupResult.an_ctrl)
-                    }
+                    addSingleAF({ groupResult, prefix: '', suffix: 'case' })
+                    addSingleAF({ groupResult, prefix: '', suffix: 'ctrl' })
+                    addOverallAF({ groupResult, prefix: '' })
                   }
 
                   if (datasetId === 'GP2') {
-                    if (groupResult.wgs_ac_case === null || groupResult.wgs_an_case === null) {
-                      groupResult.wgs_af_case = null
-                    } else if (groupResult.wgs_an_case === 0) {
-                      groupResult.wgs_af_case = 0
-                    } else {
-                      groupResult.wgs_af_case = groupResult.wgs_ac_case / groupResult.wgs_an_case
-                    }
-
-                    if (groupResult.wgs_ac_ctrl === null || groupResult.wgs_an_ctrl === null) {
-                      groupResult.wgs_af_ctrl = null
-                    } else if (groupResult.wgs_an_ctrl === 0) {
-                      groupResult.wgs_af_ctrl = 0
-                    } else {
-                      groupResult.wgs_af_ctrl = groupResult.wgs_ac_ctrl / groupResult.wgs_an_ctrl
-                    }
-
-                    if (groupResult.wgs_ac_other === null || groupResult.wgs_an_other === null) {
-                      groupResult.wgs_af_other = null
-                    } else if (groupResult.wgs_an_other === 0) {
-                      groupResult.wgs_af_other = 0
-                    } else {
-                      groupResult.wgs_af_other = groupResult.wgs_ac_other / groupResult.wgs_an_other
-                    }
-
-                    if (groupResult.ces_ac_case === null || groupResult.ces_an_case === null) {
-                      groupResult.ces_af_case = null
-                    } else if (groupResult.ces_an_case === 0) {
-                      groupResult.ces_af_case = 0
-                    } else {
-                      groupResult.ces_af_case = groupResult.ces_ac_case / groupResult.ces_an_case
-                    }
-
-                    if (groupResult.wgs_af_case === null || groupResult.wgs_af_ctrl === null) {
-                      groupResult.wgs_af = null
-                    } else if (groupResult.wgs_an_case + groupResult.wgs_an_ctrl === 0) {
-                      groupResult.wgs_af = 0
-                    } else {
-                      groupResult.wgs_af =
-                        (groupResult.wgs_ac_case + groupResult.wgs_ac_ctrl) /
-                        (groupResult.wgs_an_case + groupResult.wgs_an_ctrl)
-                    }
+                    addSingleAF({ groupResult, prefix: 'wgs_', suffix: 'case' })
+                    addSingleAF({ groupResult, prefix: 'wgs_', suffix: 'ctrl' })
+                    addSingleAF({ groupResult, prefix: 'wgs_', suffix: 'other' })
+                    addSingleAF({ groupResult, prefix: 'ces_', suffix: 'case' })
+                    addOverallAF({ groupResult, prefix: 'wgs_' })
                   }
 
                   variant.group_results[group] = groupResult

--- a/src/browsers/gp2/GP2Browser.js
+++ b/src/browsers/gp2/GP2Browser.js
@@ -164,7 +164,7 @@ const GP2Browser = () => {
         },
       ]}
       variantConsequences={variantConsequences}
-      renderVariantAttributes={({ cadd, clinvar_variation_id: clinvarID }) => [
+      renderVariantAttributes={({ cadd, clinvar_variation_id: clinvarID, rsid }) => [
         { label: 'CADD', content: cadd === null ? '-' : cadd },
         {
           label: (
@@ -179,6 +179,19 @@ const GP2Browser = () => {
               <ExternalLink href={`https://www.ncbi.nlm.nih.gov/clinvar/variation/${clinvarID}/`}>
                 {clinvarID}
               </ExternalLink>
+            ),
+        },
+        {
+          label: (
+            <TooltipAnchor tooltip="rsids from dbSNP version 154">
+              <TooltipHint>dnSNP rsid</TooltipHint>
+            </TooltipAnchor>
+          ),
+          content:
+            rsid === null ? (
+              '-'
+            ) : (
+              <ExternalLink href={`https://www.ncbi.nlm.nih.gov/snp/${rsid}/`}>{rsid}</ExternalLink>
             ),
         },
       ]}


### PR DESCRIPTION
Currently, the GRCh38 data sources are in line with data from gnomAD v3 (e.g. Gencode 29), this PR updates them to the data versions that gnomAD v4 uses (e.g. Gencode 39).