### PR TITLE
Fix: update dockerfile to handle env vars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ COPY --chown=node:node src/browsers ./src/browsers
 
 # Build frontend
 COPY --chown=node:node build.env .
-RUN export "$(xargs < build.env)"; yarn run build
+RUN set -a && . ./build.env && set +a && yarn run build
 
 ###############################################################################
 FROM --platform=linux/amd64 node:16.13.1-alpine


### PR DESCRIPTION
A change in the format of `build.env` by me caused the environment variable setting in the dockerfile to break, causing the google analytics IDs to not be set.

With the environment variables being set, and the IDs being updated from the end-of-life'd UA ids to the new GA4 ids, Google Analytics now receives data from the Exome Results Browsers.