### PR TITLE
Rig API for BipEx2 demo

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -173,14 +173,15 @@ if (isDevelopment) {
   )
   getDatasetForRequest = () => devDataset
 } else {
-  const datasetBySubdomain: Record<string, string> = Object.keys(metadata.datasets).reduce(
-    (acc, dataset) => ({
-      ...acc,
-      [dataset.toLowerCase()]: dataset,
-    }),
-    {}
-  )
-  getDatasetForRequest = (req: express.Request) => datasetBySubdomain[req.subdomains[0]]
+  // const datasetBySubdomain: Record<string, string> = Object.keys(metadata.datasets).reduce(
+  //   (acc, dataset) => ({
+  //     ...acc,
+  //     [dataset.toLowerCase()]: dataset,
+  //   }),
+  //   {}
+  // )
+  // getDatasetForRequest = (req: express.Request) => datasetBySubdomain[req.subdomains[0]]
+  getDatasetForRequest = () => 'BipEx2'
 }
 
 // ================================================================================================

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -173,19 +173,19 @@ if (isDevelopment) {
   )
   getDatasetForRequest = () => devDataset
 } else {
-
   const subdomainOverrides: Record<string, string> = {
     ibdseq: 'IBD',
   };
 
-  const datasetBySubdomain: Record<string, string> = Object.keys(metadata.datasets).reduce(
-    (acc, dataset) => ({
-      ...acc,
-      [dataset.toLowerCase()]: dataset,
-    }),
-    { ...subdomainOverrides }
-  );
-  getDatasetForRequest = (req: express.Request) => datasetBySubdomain[req.subdomains[0]]
+  // const datasetBySubdomain: Record<string, string> = Object.keys(metadata.datasets).reduce(
+  //   (acc, dataset) => ({
+  //     ...acc,
+  //     [dataset.toLowerCase()]: dataset,
+  //   }),
+  //   {}
+  // )
+  // getDatasetForRequest = (req: express.Request) => datasetBySubdomain[req.subdomains[0]]
+  getDatasetForRequest = () => 'BipEx2'
 }
 
 // ================================================================================================


### PR DESCRIPTION
The code relevant to the BipEx2 browser is in main, this draft PR is just to be used to manually rig the demo browser to render and query the BipEx2 portion of this repo.

In production, this is handled by the subdomain, e.g. epi25.broadinstitute.org.

In demo, we currently just use a random ingress. Thus, to render the BipEx2 browser here we manually set the relevant variable to always be BipEx2.

This PR should not be merged into main.

In the future, we could use the domain Steve registered with the intent of hosting demos (something like thetgg.dev I believe?) and then we could test subdomains working, for now, this band aid works.