### PR TITLE
Update schema2 search

### DIFF
--- a/src/browsers/base/DownloadsPage.tsx
+++ b/src/browsers/base/DownloadsPage.tsx
@@ -18,7 +18,7 @@ const downloadUrl = (datasetId: DatasetId, file: string) => {
   } else if (datasetId === 'BipEx2') {
     return `https://storage.googleapis.com/exome-results-browsers-public/downloads/2026-04-14/BipEx2/BipEx2_${file}`
   } else if (datasetId === 'SCHEMA2') {
-    return `https://storage.googleapis.com/exome-results-browsers-public/downloads/2026-05-07/SCHEMA2/SCHEMA2_${file}`
+    return `https://storage.googleapis.com/exome-results-browsers-public/downloads/2026-05-26/SCHEMA2/SCHEMA2_${file}`
   } else if (datasetId === 'IBD') {
     return `https://storage.googleapis.com/exome-results-browsers-public/downloads/2026-05-11/IBD/IBD_${file}`
   }

--- a/src/browsers/base/GeneResultsPage/GeneResultsPage.tsx
+++ b/src/browsers/base/GeneResultsPage/GeneResultsPage.tsx
@@ -66,7 +66,8 @@ const GeneResultsPage = ({
       (result) =>
         (result.gene_id || '').includes(searchText) ||
         (result.gene_symbol || '').includes(searchText) ||
-        (result.gene_name || '').toUpperCase().includes(searchText)
+        (result.gene_name || '').toUpperCase().includes(searchText) ||
+        (result.group_results[selectedAnalysisGroup].gene_symbol || '').toUpperCase().includes(searchText)
     )
     .map((result) => ({
       ...result,


### PR DESCRIPTION
Allow searching on `gene_symbol` from the currently selected `group_result` on the all genes page.

This allows for other gene names to be displayed on the gene list page via the group results.