### PR TITLE
Add ClinVar dataset and track

### DIFF
--- a/data_pipeline/data_pipeline/datasets/clinvar/clinvar_grch38.py
+++ b/data_pipeline/data_pipeline/datasets/clinvar/clinvar_grch38.py
@@ -1,0 +1,88 @@
+import hail as hl
+
+from data_pipeline.config import pipeline_config
+
+
+def filter_clinvar_table_to_test_gene_interval(ht_clinvar):
+
+    # ENSG00000169174
+    pcsk9_interval = hl.locus_interval(
+        "chr1", 55039447, 55064852, reference_genome="GRCh38", includes_start=True, includes_end=True
+    )
+
+    # ENSG00000177628
+    gba1_interval = hl.locus_interval(
+        "chr1", 155234452, 155244699, reference_genome="GRCh38", includes_start=True, includes_end=True
+    )
+
+    # ENSG00000177663
+    il17ra_interval = hl.locus_interval(
+        "chr22", 17084954, 17115694, reference_genome="GRCh38", includes_start=True, includes_end=True
+    )
+
+    ht_clinvar = hl.filter_intervals(ht_clinvar, [pcsk9_interval, gba1_interval, il17ra_interval])
+
+    return ht_clinvar
+
+
+def prepare_clinvar_variants(test_genes):
+    # ht_clinvar = hl.read_table(pipeline_config.get("reference_data", "clinvar_grch38_path"))
+    ht_clinvar = hl.read_table(pipeline_config.get("ClinVarGRCh38", "variant_results_path"))
+
+    if test_genes:
+        ht_clinvar = filter_clinvar_table_to_test_gene_interval(ht_clinvar)
+
+    ht_clinvar.describe()
+
+    def get_best_consequence(csq_array):
+        mane_csqs = csq_array.filter(lambda c: c.is_mane_select)
+        canonical_csqs = csq_array.filter(lambda c: c.is_canonical)
+
+        return hl.or_else(
+            mane_csqs.first(),
+            hl.or_else(canonical_csqs.first(), csq_array.first()),  # most severe if no mane_select or canonical
+        )
+
+    ht_clinvar = ht_clinvar.annotate(best_csq=get_best_consequence(ht_clinvar.transcript_consequences))
+
+    ht_clinvar = ht_clinvar.annotate(
+        transcript_id=ht_clinvar.best_csq.transcript_id,
+        major_consequence=ht_clinvar.best_csq.major_consequence,
+        hgvsp=ht_clinvar.best_csq.hgvsp,
+        hgvsc=ht_clinvar.best_csq.hgvsc,
+        gene_id=ht_clinvar.best_csq.gene_id,
+        gene_symbol=ht_clinvar.best_csq.gene_symbol,
+        consequence="other",
+        group_results=hl.dict([("meta", hl.struct())]),
+        info=hl.struct(
+            gene_id=ht_clinvar.best_csq.gene_id,
+            gene_symbol=ht_clinvar.best_csq.gene_symbol,
+            clinvar_variation_id=ht_clinvar.clinvar_variation_id,
+            rsid=ht_clinvar.rsid,
+            review_status=ht_clinvar.review_status,
+            gold_stars=ht_clinvar.gold_stars,
+            clinical_significance=ht_clinvar.clinical_significance,
+            last_evaluated=ht_clinvar.last_evaluated,
+            transcript_id=ht_clinvar.best_csq.transcript_id,
+            major_consequence=ht_clinvar.best_csq.major_consequence,
+        ),
+    )
+
+    ht_clinvar = ht_clinvar.select_globals()
+
+    ht_clinvar = ht_clinvar.select(
+        # [locus, alleles] from key
+        "variant_id",
+        "pos",
+        "consequence",
+        "hgvsc",
+        "hgvsp",
+        #
+        "gene_id",
+        "gene_symbol",
+        #
+        "group_results",
+        "info",
+    )
+
+    return ht_clinvar

--- a/data_pipeline/data_pipeline/datasets/clinvar/clinvar_grch38_dummy_genes.py
+++ b/data_pipeline/data_pipeline/datasets/clinvar/clinvar_grch38_dummy_genes.py
@@ -1,0 +1,96 @@
+# TK: This is just Epi25 to make the current pipeline not complain, as it
+#     expects a gene results table for the combine step. For now for ClinVar
+#     just give it this, and ignore it on the frontend
+
+import hail as hl
+
+from data_pipeline.config import pipeline_config
+
+
+def filter_results_table_to_test_gene(results):
+    # TK: use pcsk9 for now while we're using Epi25 as our gene data
+    test_gene_symbols = ["PCSK9"]
+    test_gene_set = hl.literal(test_gene_symbols)
+
+    results = results.filter(test_gene_set.contains(results.gene_symbol))
+
+    return results.persist()
+
+
+def prepare_gene_results(_test_genes, _output_root):
+    results = hl.read_table(pipeline_config.get("Epi25", "gene_results_path"))
+
+    # TK: make this if conditional off of test_genes in the future, for now,
+    #     always subset as there
+    #     no ClinVar gene data, and we're using epi25 data just to
+    #     appease the pipeline
+    if True:  # pylint: disable=using-constant-test
+        results = filter_results_table_to_test_gene(results)
+
+    results = results.select_globals()
+
+    # Select result fields, discard gene information
+    results = results.select(
+        "gene_id",
+        "analysis_group",
+        "case_count",
+        "control_count",
+        "n_cases",
+        "n_controls",
+        "pval",
+        "OR",
+    )
+
+    results = results.annotate(OR=hl.float(results.OR))
+
+    # Rename EE group to DEE
+    results = results.annotate(analysis_group=hl.if_else(results.analysis_group == "EE", "DEE", results.analysis_group))
+
+    final_results = None
+
+    consequence_categories = results.aggregate(hl.agg.collect_as_set(results.consequence_category))
+    per_category_fields = [
+        "case_count",
+        "control_count",
+        "pval",
+        "OR",
+    ]
+    for category in consequence_categories:
+        category_results = results.filter(results.consequence_category == category)
+        category_results = category_results.key_by("gene_id", "analysis_group")
+        category_results = category_results.select(
+            n_cases=category_results.n_cases,
+            n_controls=category_results.n_controls,
+            **{f"{category}_{field}": category_results[field] for field in per_category_fields},
+        )
+
+        if final_results:
+            final_results = final_results.join(category_results.drop("n_cases", "n_controls"), "outer")
+
+            # N cases/controls should be the same for all consequence categories for a gene/analysis group.
+            # However, if there are no variants of a certain consequence category found in a gene, then
+            # N cases/controls for that gene/analysis group/consequence category will be missing.
+            final_results = final_results.annotate(
+                n_cases=hl.or_else(
+                    final_results.n_cases, category_results[final_results.gene_id, final_results.analysis_group].n_cases
+                ),
+                n_controls=hl.or_else(
+                    final_results.n_controls,
+                    category_results[final_results.gene_id, final_results.analysis_group].n_controls,
+                ),
+            )
+        else:
+            final_results = category_results
+
+    final_results = final_results.group_by("gene_id").aggregate(
+        group_results=hl.agg.collect(final_results.row.drop("gene_id"))
+    )
+    final_results = final_results.annotate(
+        group_results=hl.dict(
+            final_results.group_results.map(
+                lambda group_result: (group_result.analysis_group, group_result.drop("analysis_group"))
+            )
+        )
+    )
+
+    return final_results

--- a/data_pipeline/data_pipeline/pipelines/prepare_datasets.py
+++ b/data_pipeline/data_pipeline/pipelines/prepare_datasets.py
@@ -81,6 +81,19 @@ def prepare_dataset(dataset_id, test_genes, output_local):
         validate_gene_results_table(gene_results)
         gene_results.write(os.path.join(output_path, "gene_results.ht"), overwrite=True)
 
+    elif dataset_id.lower() == "ClinVarGRCh38".lower():
+        print(f"\n\n === Preparing {dataset_id} variants hail table")
+        clinvar_grch38_module = importlib.import_module("data_pipeline.datasets.clinvar.clinvar_grch38")
+
+        ht_clinvar_variants = clinvar_grch38_module.prepare_clinvar_variants(test_genes)
+        ht_clinvar_variants.write(os.path.join(output_path, "variant_results.ht"), overwrite=True)
+
+        clinvar_grch38_dummy_genes_module = importlib.import_module(
+            "data_pipeline.datasets.clinvar.clinvar_grch38_dummy_genes"
+        )
+        ht_clinvar_genes = clinvar_grch38_dummy_genes_module.prepare_gene_results(test_genes, output_root)
+        ht_clinvar_genes.write(os.path.join(output_path, "gene_results.ht"), overwrite=True)
+
     else:
         print(f"\n\n === Preparing {dataset_id} variants hail table")
         variant_results_module = importlib.import_module(
@@ -130,7 +143,7 @@ def main():
     else:
         datasets_to_prepare = all_datasets
 
-    print(f"\nPrepareing datasets: {list(datasets_to_prepare)} ...\n\n")
+    print(f"\nPreparing datasets: {list(datasets_to_prepare)} ...\n\n")
 
     # hl.init()
     hl.init(

--- a/data_pipeline/pipeline_config.ini
+++ b/data_pipeline/pipeline_config.ini
@@ -1,5 +1,5 @@
 [datasets]
-datasets = ASC,BipEx,BipEx2,Epi25,SCHEMA,SCHEMA2,IBD,GP2
+datasets = ASC,BipEx,BipEx2,Epi25,SCHEMA,SCHEMA2,IBD,GP2,ClinVarGRCh38
 
 [ASC]
 gene_results_path = gs://asc-browser/ASC_gene_results_table_for_browser_2019-04-14.tsv
@@ -70,6 +70,11 @@ combined_variant_annotations_path = gs://gp2-parkinsons-browser/2025-09-17/combi
 
 output_last_updated = 2025-09-18
 
+[ClinVarGRCh38]
+variant_results_path = gs://exome-results-browsers/clinvar/clinvar-grch38-2026-06-06.ht
+
+output_last_updated = 2026-06-15
+
 [reference_data]
 grch37_gencode_path = gs://exome-results-browsers/reference/gencode.v19.gtf.bgz
 grch38_gencode_path = gs://exome-results-browsers/reference/gencode.v39.gtf.bgz
@@ -105,4 +110,4 @@ local_output_root = data/output-data
 gcs_downloads_output_root = gs://exome-results-browsers-public/downloads
 local_downloads_output_root = data/downloads
 
-output_last_updated = 2026-06-09
+output_last_updated = 2026-06-15

--- a/src/browsers/base/Browser.tsx
+++ b/src/browsers/base/Browser.tsx
@@ -53,6 +53,11 @@ declare global {
       variant_group_result_field_types: string[]
       variant_info_field_names: string[]
       variant_info_field_types: string[]
+      clinvar?: {
+        variant_fields: string[]
+        variant_info_field_names: string[]
+        variant_info_field_types: string[]
+      }
     }
     gaTrackingId: string
     gtag: Gtag.Gtag

--- a/src/browsers/base/GenePage/BinnedVariantsPlot.tsx
+++ b/src/browsers/base/GenePage/BinnedVariantsPlot.tsx
@@ -1,0 +1,133 @@
+// @ts-expect-error: no types
+import { scaleLinear } from 'd3-scale'
+import React from 'react'
+import styled from 'styled-components'
+
+// @ts-expect-error: no types for now
+import { TooltipAnchor } from '@gnomad/ui'
+
+const BinHoverTarget = styled.rect`
+  pointer-events: visible;
+  fill: none;
+
+  &:hover {
+    fill: rgba(0, 0, 0, 0.05);
+  }
+`
+
+type OwnProps = {
+  categoryColor?: (...args: any[]) => any
+  formatTooltip: (...args: any[]) => any
+  height?: number
+  scalePosition: (...args: any[]) => any
+  variantCategory?: (...args: any[]) => any
+  variantCategories?: string[]
+  variants: any[]
+  width: number
+}
+
+// @ts-expect-error TS(2456) FIXME: Type alias 'Props' circularly references itself.
+type Props = OwnProps & typeof BinnedVariantsPlot.defaultProps
+
+// @ts-expect-error TS(7022) FIXME: 'BinnedVariantsPlot' implicitly has type 'any' bec... Remove this comment to see the full error message
+const BinnedVariantsPlot = ({
+  categoryColor,
+  formatTooltip,
+  height,
+  scalePosition,
+  variantCategory,
+  variantCategories,
+  variants,
+  width,
+}: Props) => {
+  const nBins = Math.min(100, Math.floor(width / 8))
+  const binWidth = width / nBins
+  const binPadding = 1
+
+  const initialCategoryCounts = variantCategories.reduce(
+    // @ts-expect-error TS(7006) FIXME: Parameter 'acc' implicitly has an 'any' type.
+    (acc, category) => ({
+      ...acc,
+      [category]: 0,
+    }),
+    {}
+  )
+  const bins = [...Array(nBins)].map(() => ({ ...initialCategoryCounts }))
+
+  const variantBinIndex = (variant: any) => {
+    const variantPosition = scalePosition(variant.pos)
+    return Math.floor(variantPosition / binWidth)
+  }
+
+  variants.forEach((variant: any) => {
+    const category = variantCategory(variant)
+    const binIndex = variantBinIndex(variant)
+    if (binIndex >= 0 && binIndex < bins.length) {
+      bins[binIndex][category] += 1
+    }
+  })
+
+  const maxVariantsInBin = bins.reduce((max, bin) => {
+    const binTotal = Object.values(bin).reduce((a: any, b: any) => a + b, 0)
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'unknown' is not assignable to pa... Remove this comment to see the full error message
+    return Math.max(max, binTotal)
+  }, 1)
+
+  const y = scaleLinear().domain([0, maxVariantsInBin]).range([0, height])
+
+  return (
+    <svg height={height} width={width} style={{ overflow: 'visible' }}>
+      <g>
+        <text x={-7} y={0} dy="0.3em" textAnchor="end">
+          {maxVariantsInBin}
+        </text>
+        <line x1={-5} y1={0} x2={0} y2={0} stroke="#000" strokeWidth={1} />
+
+        <text x={-7} y={height} dy="0.3em" textAnchor="end">
+          0
+        </text>
+        <line x1={-5} y1={height} x2={0} y2={height} stroke="#000" strokeWidth={1} />
+
+        <line x1={0} y1={0} x2={0} y2={height} stroke="#000" strokeWidth={1} />
+      </g>
+      <g>
+        {bins.map((bin, binIndex) => {
+          let yOffset = 0
+          return (
+            // eslint-disable-next-line react/no-array-index-key
+            <g key={binIndex} transform={`translate(${binIndex * binWidth + binPadding},0)`}>
+              {variantCategories.map((category: any) => {
+                const barHeight = y(bin[category])
+                const bar = (
+                  <rect
+                    key={category}
+                    x={binPadding}
+                    y={height - yOffset - barHeight}
+                    width={binWidth - binPadding * 2}
+                    height={barHeight}
+                    fill={categoryColor(category)}
+                  />
+                )
+                yOffset += barHeight
+                return bar
+              })}
+              <TooltipAnchor tooltip={formatTooltip(bin)}>
+                <BinHoverTarget x={0} y={0} height={height} width={binWidth} />
+              </TooltipAnchor>
+            </g>
+          )
+        })}
+      </g>
+      <line x1={0} y1={height} x2={width} y2={height} stroke="#000" />
+    </svg>
+  )
+}
+
+BinnedVariantsPlot.defaultProps = {
+  categoryColor: () => '#424242',
+  height: 50,
+  variantCategory: () => 'undefined',
+  variantCategories: ['undefined'],
+}
+
+export default BinnedVariantsPlot

--- a/src/browsers/base/GenePage/ClinVarVariantsInGene.tsx
+++ b/src/browsers/base/GenePage/ClinVarVariantsInGene.tsx
@@ -1,0 +1,374 @@
+
+import React, { useContext, useState } from 'react'
+import styled from 'styled-components'
+import Fetch from '../Fetch'
+import StatusMessage from '../StatusMessage'
+import { ConsequenceCategory, DatasetId, VariantConsequence, VariantConsequenceCategoryLabels } from '../Browser'
+
+// @ts-expect-error: no types in this version of @gnomad/ui
+import { CategoryFilterControl, KeyboardShortcut, List, ListItem } from '@gnomad/ui'
+
+// @ts-expect-error: no types in this version of @gnomad/region-viewer
+import { RegionViewerContext } from '@gnomad/region-viewer'
+
+import BinnedVariantsPlot from './BinnedVariantsPlot'
+
+import {
+  CLINICAL_SIGNIFICANCE_CATEGORIES,
+  CLINICAL_SIGNIFICANCE_CATEGORY_LABELS,
+  CLINICAL_SIGNIFICANCE_CATEGORY_COLORS,
+  clinvarVariantClinicalSignificanceCategory,
+  ClinicalSignificance,
+} from './clinvarVariantCategories'
+import { TrackPageSection } from './TrackPage'
+import { FiltersFirstColumn, FiltersWrapper, SettingsWrapper } from './VariantFilterControls'
+import { Gene } from './VariantsInGene'
+import { VariantRow } from './variantTableColumns'
+import datasetConfig from '../../datasetConfig'
+
+const TooltipContent = styled.div`
+  line-height: 1;
+  text-align: left;
+
+  ${List} {
+    /* margin-top: 0; */
+  }
+
+  ${ListItem} {
+    &:last-child {
+      margin: 0;
+    }
+  }
+
+  p {
+    margin-bottom: 0.5em;
+  }
+`
+
+// TK: can be removed when we bump gnomAD browser toolkit version
+//    in favor of type from that package
+type ScalePosition = {
+  (position: number): number
+  invert: (x: number) => number
+}
+
+type IncludedCategories = {
+  [key: string]: boolean
+}
+
+const formatTooltip = (bin: any, includedClinicalSignificanceCategories: IncludedCategories) => {
+  return (
+    <TooltipContent>
+      This bin contains:
+      <List>
+        {CLINICAL_SIGNIFICANCE_CATEGORIES.filter((category) => includedClinicalSignificanceCategories[category]).map(
+          (category) => {
+            return (
+              <ListItem key={category}>
+                {/* @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message */}
+                {bin[category]} {CLINICAL_SIGNIFICANCE_CATEGORY_LABELS[category].toLowerCase()}{' '}
+                variant{bin[category] !== 1 ? 's' : ''}
+              </ListItem>
+            )
+          }
+        )}
+      </List>
+    </TooltipContent>
+  )
+}
+
+type ClinVarVariant = {
+  variant_id: string,
+  clinical_variation_id: string,
+  rsid: string,
+
+  pos: number,
+
+  clinical_significance: string,
+  consequence: string,
+  consequenceCategory: string,
+  review_status: string,
+
+  gold_stars: number,
+  last_evaluated: string,
+  major_consequence: string,
+
+  gene_id: string,
+  gene_symbol: string,
+  transcript_id: string,
+  hgvs: string,
+  hgvsc: string | null,
+  hgvsp: string | null,
+
+  [key: string]: any
+}
+
+type ClinVarBinnedVariantsInGeneProps = {
+  centerPanelWidth: number,
+  scalePosition: ScalePosition,
+  clinvarVariants: ClinVarVariant[]
+  includedClinicalSignificanceCategories: IncludedCategories
+}
+
+
+const ClinVarBinnedVariantsInGene = ({
+  centerPanelWidth,
+  scalePosition,
+  clinvarVariants,
+  includedClinicalSignificanceCategories,
+}: ClinVarBinnedVariantsInGeneProps) => {
+
+  return (
+    <BinnedVariantsPlot
+      width={centerPanelWidth}
+      scalePosition={scalePosition}
+      variants={clinvarVariants}
+      categoryColor={(category: ClinicalSignificance) => CLINICAL_SIGNIFICANCE_CATEGORY_COLORS[category]}
+      formatTooltip={(bin: any) => formatTooltip(bin, includedClinicalSignificanceCategories)}
+      variantCategory={clinvarVariantClinicalSignificanceCategory}
+      variantCategories={CLINICAL_SIGNIFICANCE_CATEGORIES}
+    />
+  )
+}
+
+type ClinicalSignificanceConsequenceCategoryLabels = Record<ClinicalSignificance, string>
+
+interface ClinVarFilterControlsProps {
+  filter: ClinVarVariantsInGeneFilter
+  setFilter: any
+  clinicalSignificanceCategoryLabels?: ClinicalSignificanceConsequenceCategoryLabels
+}
+
+const defaultClinicalSignificanceCategoryLables: ClinicalSignificanceConsequenceCategoryLabels = {
+  "pathogenic": "Pathogenic / likely pathogenic",
+  "uncertain": "Uncertain significance / conflicting",
+  "benign": "Benign / likely benign",
+  "other": "Other",
+}
+
+const ClinVarFilterControls = ({
+  filter,
+  setFilter,
+  clinicalSignificanceCategoryLabels = defaultClinicalSignificanceCategoryLables,
+}: ClinVarFilterControlsProps) => {
+  return (
+    <SettingsWrapper>
+      <FiltersWrapper>
+        <FiltersFirstColumn>
+          <CategoryFilterControl
+            categories={CLINICAL_SIGNIFICANCE_CATEGORIES.map((category) => ({
+              id: category,
+              label: clinicalSignificanceCategoryLabels[category as ClinicalSignificance] || category,
+              className: 'category',
+              color: CLINICAL_SIGNIFICANCE_CATEGORY_COLORS[category as ClinicalSignificance],
+            }))}
+            categorySelections={filter.includedClinicalSignificanceCategories}
+            id="clinvar-variant-consequence-category-filter"
+            onChange={(includeCategories: Record<ClinicalSignificance, boolean>) => {
+              setFilter({
+                ...filter,
+                includedClinicalSignificanceCategories: includeCategories
+              })
+            }}
+          />
+        </FiltersFirstColumn>
+      </FiltersWrapper>
+    </SettingsWrapper>
+  )
+}
+
+interface ClinVarVariantsInGeneProps {
+  leftPanelWidth: number,
+  centerPanelWidth: number,
+  scalePosition: ScalePosition,
+  clinvarVariants: ClinVarVariant[],
+  consequenceCategoryLabels: VariantConsequenceCategoryLabels,
+}
+
+interface ClinVarVariantsInGeneFilter {
+  includedConsequenceCategories: Record<ConsequenceCategory, boolean>
+  includedClinicalSignificanceCategories: Record<ClinicalSignificance, boolean>
+}
+
+
+// TK: this is more or less a copy-pasta of gnomAD browser's
+//     'ClinVarBinnedVariantsPlots.tsx' file, with some small modifications
+//     Here we don't support unbinning for now, instead telling users to go
+//     to gnomAD proper for that functionality
+// In the future, we should pull this binned component into a shared
+//     components repo, like `gnomad-browser-toolkit`
+const ClinVarVariantsInGene = ({
+  leftPanelWidth,
+  centerPanelWidth,
+  scalePosition,
+  clinvarVariants,
+}: ClinVarVariantsInGeneProps) => {
+  const defaultFilterState: ClinVarVariantsInGeneFilter = {
+    includedClinicalSignificanceCategories: {
+      pathogenic: true,
+      uncertain: true,
+      benign: true,
+      other: true,
+    },
+    includedConsequenceCategories: {
+      lof: true,
+      missense: true,
+      synonymous: true,
+      other: true,
+    },
+  }
+
+  const [filter, setFilter] = useState<ClinVarVariantsInGeneFilter>(defaultFilterState)
+
+  const includedClinicalSignificanceCategories = filter.includedClinicalSignificanceCategories
+  const includedClinicalSignificanceCategoriesArray = Object.keys(includedClinicalSignificanceCategories)
+    .filter((key) => includedClinicalSignificanceCategories[key as ClinicalSignificance]);
+  const filteredClinvarVariants: ClinVarVariant[] = clinvarVariants.filter((clinvarVariant) => {
+    return (
+      includedClinicalSignificanceCategoriesArray.includes(clinvarVariantClinicalSignificanceCategory(clinvarVariant))
+    )
+  })
+
+  return (
+    <>
+      <div style={{ marginBottom: '1em' }}>
+        <div style={{ marginLeft: leftPanelWidth }}>
+          <ClinVarFilterControls
+            filter={filter}
+            setFilter={setFilter}
+          />
+        </div>
+
+        <InnerWrapper>
+          <div style={{ width: leftPanelWidth, display: 'flex', alignItems: 'center' }}>
+            <p style={{ marginLeft: 0 }}>{`ClinVar variants (${filteredClinvarVariants.length})`}</p>
+          </div>
+          <div>
+            <ClinVarBinnedVariantsInGene
+              centerPanelWidth={centerPanelWidth}
+              scalePosition={scalePosition}
+              clinvarVariants={filteredClinvarVariants}
+              includedClinicalSignificanceCategories={filter.includedClinicalSignificanceCategories}
+            />
+          </div>
+        </InnerWrapper>
+      </div >
+    </>
+  )
+}
+
+const defaultConsequenceCategoryLabels: VariantConsequenceCategoryLabels = {
+  "other": "Other",
+  "lof": "LoF",
+  "missense": "Missense",
+  "synonymous": "Synonymous",
+}
+
+interface ClinVarVariantsInGeneContainerProps {
+  datasetId: DatasetId
+  gene: Gene
+  variantConsequences: VariantConsequence[]
+  consequenceCategoryLabels?: VariantConsequenceCategoryLabels,
+}
+
+
+const InnerWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+`
+
+const ClinVarVariantsInGeneContainer = ({
+  datasetId,
+  gene,
+  variantConsequences,
+  consequenceCategoryLabels = defaultConsequenceCategoryLabels,
+}: ClinVarVariantsInGeneContainerProps) => {
+  // @ts-expect-error - no types from RegionViewerContext in this GBTK version
+  const { leftPanelWidth, centerPanelWidth, scalePosition } = useContext(RegionViewerContext)
+
+  const datasetsWithClinVar: DatasetId[] = ['GP2']
+  const givenDatasetHasClinvar = datasetsWithClinVar.indexOf(datasetId) !== -1
+  if (!givenDatasetHasClinvar) {
+    return null
+  }
+
+  return (
+    <Fetch path={`/gene/${gene.gene_id}/variants?dataset=ClinVarGRCh38`}>
+      {({
+        data: clinvarData,
+        error: clinvarError,
+        loading: clinvarLoading }) => {
+
+        if (clinvarLoading) {
+          return <StatusMessage>Loading variants...</StatusMessage>
+        }
+
+        if (clinvarError || !(clinvarData || {}).variants) {
+          return <StatusMessage>Unable to load variants</StatusMessage>
+        }
+
+        const consequences: Record<string, { label: string; category: string }> = {}
+        variantConsequences.forEach((csq) => {
+          consequences[csq.term] = {
+            label: csq.label || csq.term,
+            category: csq.category || 'other',
+          }
+        })
+
+        const windowObjectHasClinvarMetadata = datasetConfig.clinvar
+        if (!windowObjectHasClinvarMetadata) {
+          return (
+            <>No ClinVar variants found</>
+          )
+        } else {
+          const clinvarVariants: ClinVarVariant[] = clinvarData.variants.map((rawClinvarVariant: VariantRow[]) => {
+            const clinvarVariant: {
+              [key: string]: any
+            } = {}
+
+            datasetConfig.clinvar!.variant_fields
+              .filter((field) => ['group_results'].indexOf(field) === -1)
+              .forEach((field, fieldIndex) => {
+                if (field === 'info') {
+                  datasetConfig.clinvar!.variant_info_field_names
+                    .forEach((infoField, infoFieldIndex) => {
+                      clinvarVariant[infoField] = rawClinvarVariant[fieldIndex][infoFieldIndex]
+                    })
+                } else {
+                  clinvarVariant[field] = rawClinvarVariant[fieldIndex]
+                }
+              })
+
+            clinvarVariant.hgvs = clinvarVariant.hgvsp || clinvarVariant.hgvsc
+
+            if (clinvarVariant.consequence) {
+              clinvarVariant.consequenceCategory =
+                (consequences[clinvarVariant.consequence] || {}).category || 'other'
+              clinvarVariant.consequence =
+                (consequences[clinvarVariant.consequence] || {}).label || clinvarVariant.consequence
+            } else {
+              clinvarVariant.consequenceCategory = 'other'
+            }
+
+            return clinvarVariant
+          })
+
+
+          return (
+            <ClinVarVariantsInGene
+              leftPanelWidth={leftPanelWidth}
+              centerPanelWidth={centerPanelWidth}
+              scalePosition={scalePosition}
+              clinvarVariants={clinvarVariants}
+              consequenceCategoryLabels={consequenceCategoryLabels}
+            />
+          )
+        }
+
+      }}
+    </Fetch>
+  )
+}
+
+export default ClinVarVariantsInGeneContainer

--- a/src/browsers/base/GenePage/GenePage.tsx
+++ b/src/browsers/base/GenePage/GenePage.tsx
@@ -208,26 +208,26 @@ const GenePageContainer = ({
   return (
     <Fetch path={`/gene/${geneIdOrSymbol}`}>
       {({
-        data,
-        error,
-        loading,
+        data: geneData,
+        error: geneError,
+        loading: geneLoading,
       }: {
         data: { gene: IndividualGeneAPIResponse }
         error: Error | null
         loading: boolean
       }) => {
-        if (loading) {
+        if (geneLoading) {
           return <StatusMessage>Loading gene...</StatusMessage>
         }
 
-        if (error || !(data || {}).gene) {
-          return <StatusMessage>{error?.message || 'Unable to load gene'}</StatusMessage>
+        if (geneError || !(geneData || {}).gene) {
+          return <StatusMessage>{geneError?.message || 'Unable to load gene'}</StatusMessage>
         }
 
         return (
           <GenePage
             datasetId={datasetId}
-            gene={data.gene}
+            gene={geneData.gene}
             defaultVariantAnalysisGroup={defaultVariantAnalysisGroup}
             variantAnalysisGroupOptions={variantAnalysisGroupOptions}
             variantConsequences={variantConsequences}

--- a/src/browsers/base/GenePage/GenePage.tsx
+++ b/src/browsers/base/GenePage/GenePage.tsx
@@ -15,6 +15,7 @@ import GeneResults from './GeneResults'
 import { TrackPage, TrackPageSection } from './TrackPage'
 import TranscriptTrack from './TranscriptTrack'
 import VariantsInGene from './VariantsInGene'
+import ClinVarVariantsInGene from './ClinVarVariantsInGene'
 import {
   DatasetId,
   VariantColumnConfig,
@@ -160,6 +161,12 @@ const GenePage = ({
         <TranscriptTrack
           exons={gene.canonical_transcript.exons}
           strand={gene.canonical_transcript.strand}
+        />
+        <ClinVarVariantsInGene
+          datasetId={datasetId}
+          gene={gene}
+          variantConsequences={variantConsequences}
+          consequenceCategoryLabels={variantConsequenceCategoryLabels}
         />
         <VariantsInGene
           datasetId={datasetId}

--- a/src/browsers/base/GenePage/VariantFilterControls.tsx
+++ b/src/browsers/base/GenePage/VariantFilterControls.tsx
@@ -8,14 +8,14 @@ import CSVExportButton from '../CSVExportButton'
 import { ConsequenceCategory, VariantConsequenceCategoryLabels } from '../Browser'
 import { VariantRow, VariantTableColumn } from './variantTableColumns'
 
-const consequenceCategoryColors = {
+export const consequenceCategoryColors = {
   lof: '#FF583F',
   missense: '#F0C94D',
   synonymous: 'green',
   other: '#757575',
 }
 
-const SettingsWrapper = styled.div`
+export const SettingsWrapper = styled.div`
   display: flex;
   flex-direction: row;
   justify-content: space-between;
@@ -27,7 +27,7 @@ const SettingsWrapper = styled.div`
   }
 `
 
-const FiltersWrapper = styled.div`
+export const FiltersWrapper = styled.div`
   display: flex;
   flex-grow: 2;
   flex-direction: row;
@@ -58,7 +58,7 @@ const AnalysisGroupMenuWrapper = styled.div`
   }
 `
 
-const FiltersFirstColumn = styled.div`
+export const FiltersFirstColumn = styled.div`
   display: flex;
   flex-direction: column;
 
@@ -101,7 +101,7 @@ const SearchWrapper = styled.div`
   }
 `
 
-const keyboardShortcuts: Record<ConsequenceCategory, string> = {
+export const keyboardShortcuts: Record<ConsequenceCategory, string> = {
   lof: 'l',
   missense: 'm',
   synonymous: 's',
@@ -128,7 +128,7 @@ interface VariantFilterControlProps {
   variantTableColumns: VariantTableColumn[]
 }
 
-const lofCategories: ConsequenceCategory[] = ['lof', 'missense', 'synonymous', 'other']
+export const lofCategories: ConsequenceCategory[] = ['lof', 'missense', 'synonymous', 'other']
 
 const VariantFilterControls = ({
   consequenceCategoryLabels,

--- a/src/browsers/base/GenePage/VariantsInGene.tsx
+++ b/src/browsers/base/GenePage/VariantsInGene.tsx
@@ -47,7 +47,7 @@ const selectGroupResult = (variants: VariantRow[], group: string) => {
 }
 
 // TK: TODO: fixme: this type could possibly be GeneRow from Browser.tsx
-interface Gene {
+export interface Gene {
   gene_id: string
   reference_genome: ReferenceGenome
 }

--- a/src/browsers/base/GenePage/clinvarVariantCategories.ts
+++ b/src/browsers/base/GenePage/clinvarVariantCategories.ts
@@ -1,0 +1,118 @@
+import { getCategoryFromConsequence } from '../../base/vepConsequences'
+
+export const CLINICAL_SIGNIFICANCE_CATEGORIES = ['pathogenic', 'uncertain', 'benign', 'other']
+
+const CLINICAL_SIGNIFICANCE_GROUPS = {
+  pathogenic: new Set([
+    'Pathogenic',
+    'Pathogenic/Likely pathogenic',
+    'Likely pathogenic',
+    'association',
+    'risk factor',
+  ]),
+  uncertain: new Set([
+    'Uncertain significance',
+    'Conflicting interpretations of pathogenicity',
+    'Conflicting classifications of pathogenicity',
+    'conflicting data from submitters',
+  ]),
+  benign: new Set(['Likely benign', 'Benign/Likely benign', 'Benign']),
+  other: new Set([
+    'other',
+    'drug response',
+    'Affects',
+    'protective',
+    'no interpretation for the single variant',
+    'no classification for the single variant',
+    'not provided',
+    'association not found',
+  ]),
+} as const
+
+const buildPriorityMapping = () => {
+  const mapping: { [key: string]: number } = {}
+
+  return CLINICAL_SIGNIFICANCE_CATEGORIES.reduce((acc, category, categoryIndex) => {
+    const group = CLINICAL_SIGNIFICANCE_GROUPS[category as ClinicalSignificance]
+    const groupArray = Array.from(group)
+
+    groupArray.forEach((significance, index) => {
+      acc[significance] = categoryIndex * groupArray.length + index + 1
+    })
+
+    return acc
+  }, mapping)
+}
+
+export const CLINICAL_SIGNIFICANCE_SORT_PRIORITY = buildPriorityMapping()
+
+export type ClinicalSignificance = keyof typeof CLINICAL_SIGNIFICANCE_GROUPS
+
+export const clinvarVariantClinicalSignificanceCategory = (variant: any) => {
+  const clinicalSignificances = variant.clinical_significance.split(', ')
+
+  if (clinicalSignificances.some((s: any) => CLINICAL_SIGNIFICANCE_GROUPS.pathogenic.has(s))) {
+    return 'pathogenic'
+  }
+  if (clinicalSignificances.some((s: any) => CLINICAL_SIGNIFICANCE_GROUPS.uncertain.has(s))) {
+    return 'uncertain'
+  }
+  if (clinicalSignificances.some((s: any) => CLINICAL_SIGNIFICANCE_GROUPS.benign.has(s))) {
+    return 'benign'
+  }
+  return 'other'
+}
+
+export const CLINICAL_SIGNIFICANCE_CATEGORY_LABELS = {
+  pathogenic: 'Pathogenic / likely pathogenic',
+  uncertain: 'Uncertain significance / conflicting',
+  benign: 'Benign / likely benign',
+  other: 'Other',
+}
+
+export const CLINICAL_SIGNIFICANCE_CATEGORY_COLORS = {
+  pathogenic: '#E6573D',
+  uncertain: '#FAB470',
+  benign: '#5E6F9E',
+  other: '#bababa',
+}
+
+export const CONSEQUENCE_CATEGORIES = [
+  'frameshift',
+  'other_lof',
+  'missense',
+  'splice_region',
+  'synonymous',
+  'other',
+]
+
+export const CONSEQUENCE_CATEGORY_LABELS = {
+  frameshift: 'Frameshift',
+  other_lof: 'Other pLoF',
+  missense: 'Missense',
+  splice_region: 'Splice region',
+  synonymous: 'Synonymous',
+  other: 'Other',
+}
+
+export const clinvarVariantConsequenceCategory = (variant: any) => {
+  const consequence = variant.major_consequence
+  const consequenceCategory = getCategoryFromConsequence(consequence)
+
+  if (consequence === 'frameshift_variant') {
+    return 'frameshift'
+  }
+  if (consequenceCategory === 'lof') {
+    return 'other_lof'
+  }
+  if (consequenceCategory === 'missense') {
+    return 'missense'
+  }
+  if (consequence === 'splice_region_variant') {
+    return 'splice_region'
+  }
+  if (consequence === 'synonymous_variant') {
+    return 'synonymous'
+  }
+  return 'other'
+}

--- a/src/browsers/base/vepConsequences.tsx
+++ b/src/browsers/base/vepConsequences.tsx
@@ -183,4 +183,33 @@ const vepConsequences: VariantConsequence[] = [
   },
 ]
 
+const categoryByTerm = Object.create(null)
+const labelByTerm = Object.create(null)
+
+export const VEP_CONSEQUENCE_CATEGORIES = ['lof', 'missense', 'synonymous', 'other']
+
+export const VEP_CONSEQUENCE_CATEGORY_LABELS = {
+  lof: 'pLoF',
+  missense: 'Missense / Inframe indel',
+  synonymous: 'Synonymous',
+  other: 'Other',
+}
+
+export const getCategoryFromConsequence = (consequenceTerm: any) => categoryByTerm[consequenceTerm]
+
+export const getLabelForConsequenceTerm = (consequenceTerm: any) =>
+  labelByTerm[consequenceTerm] || consequenceTerm
+
+export const getConsequenceRank = (consequenceTerm: any) =>
+  vepConsequences.findIndex((consequence: any) => consequence.term === consequenceTerm)
+
+export const registerConsequences = (consequences: any) => {
+  consequences.forEach((consequence: any) => {
+    categoryByTerm[consequence.term] = consequence.category
+    labelByTerm[consequence.term] = consequence.label
+  })
+}
+
+registerConsequences(vepConsequences)
+
 export default vepConsequences

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -319,13 +319,28 @@ app.use('/', (req: Request, res: Response, next: NextFunction) => {
 })
 
 const datasetConfig: Record<string, any> = {}
+
 const getDatasetConfigJs = (dataset: string) => {
   if (!datasetConfig[dataset]) {
+
+    const datasetsWithClinvar = ["GP2"]
+    const thisDatasetRequestsClinvar = datasetsWithClinvar.includes(dataset);
+
+    const clinVarData = metadata.datasets?.["ClinVarGRCh38"];
+
     const datasetMetadata = {
       datasetId: dataset,
+      ...(thisDatasetRequestsClinvar && {
+        clinvar: {
+          variant_fields: metadata.variant_fields,
+          variant_info_field_names: clinVarData?.variant_info_field_names ?? [],
+          variant_info_field_types: clinVarData?.variant_info_field_types ?? [],
+        }
+      }),
       ...metadata,
-      ...metadata.datasets[dataset],
+      ...metadata.datasets?.[dataset],
     }
+
     datasetConfig[dataset] = `window.datasetConfig = ${JSON.stringify(datasetMetadata)}`
   }
   return datasetConfig[dataset]

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -266,11 +266,21 @@ app.post('/api/check-auth', (req: Request, res: Response) => {
 // Middleware
 // ================================================================================================
 
+const allowedQueryParamDatasets = ["ClinVarGRCh38"]
+
 // Store dataset on request object so other route handlers can use it.
 app.use('/', (req: Request, res: Response, next: NextFunction) => {
   let dataset: any
   try {
-    dataset = getDatasetForRequest(req)
+    if (
+      req.query.dataset
+      && typeof req.query.dataset === 'string'
+      && allowedQueryParamDatasets.includes(req.query.dataset)
+    ) {
+      dataset = req.query.dataset
+    } else {
+      dataset = getDatasetForRequest(req)
+    }
   } catch (err) { } // eslint-disable-line no-empty
 
   if (!dataset) {


### PR DESCRIPTION
Adds ClinVar as a dataset to be processed, and as a track on the frontend.

The dataset is a bit non-ergonomic, as it shoves data into the `info` field for it to work with minimal changes to the existing pipeline.

Currently, the ClinVar data only renders on the `GP2` dataset, as that was a request from the analyst for this recent data update.


---

<img width="2362" height="1124" alt="Screenshot 2026-06-16 at 11 21 19" src="https://github.com/user-attachments/assets/991aa173-f904-4aa5-b0cf-0f1eccea8ce4" />
