### PR TITLE
Update BipEx2 demo with new data

### DIFF
--- a/data_pipeline/data_pipeline/datasets/bipex2/bipex2_gene_results.py
+++ b/data_pipeline/data_pipeline/datasets/bipex2/bipex2_gene_results.py
@@ -116,22 +116,34 @@ def prepare_gene_results(test_genes, _output_root):
     # Select result fields, discard gene information
     results = results.select(
         analysis_group="meta",
+        #
         syn_case_carrier=results["SYN Case Carrier"],
         syn_ctrl_carrier=results["SYN Control Carrier"],
         syn_p_value=results["SYN P-value"],
         syn_odds_ratio=results["SYN Odds Ratio"],
+        syn_odds_ratio_95_ci_lower_bound=results["SYN Odds Ratio 95% CI"][0],
+        syn_odds_ratio_95_ci_upper_bound=results["SYN Odds Ratio 95% CI"][1],
+        #
         mis_case_carrier=results["MIS Case Carrier"],
         mis_ctrl_carrier=results["MIS Control Carrier"],
         mis_p_value=results["MIS P-value"],
         mis_odds_ratio=results["MIS Odds Ratio"],
+        mis_odds_ratio_95_ci_lower_bound=results["MIS Odds Ratio 95% CI"][0],
+        mis_odds_ratio_95_ci_upper_bound=results["MIS Odds Ratio 95% CI"][1],
+        #
         ptv_case_carrier=results["PTV Case Carrier"],
         ptv_ctrl_carrier=results["PTV Control Carrier"],
         ptv_p_value=results["PTV P-value"],
         ptv_odds_ratio=results["PTV Odds Ratio"],
+        ptv_odds_ratio_95_ci_lower_bound=results["PTV Odds Ratio 95% CI"][0],
+        ptv_odds_ratio_95_ci_upper_bound=results["PTV Odds Ratio 95% CI"][1],
+        #
         ptv_mis_case_carrier=results["PTV+MIS Case Carrier"],
         ptv_mis_ctrl_carrier=results["PTV+MIS Control Carrier"],
         ptv_mis_p_value=results["PTV+MIS P-value"],
         ptv_mis_odds_ratio=results["PTV+MIS Odds Ratio"],
+        ptv_mis_odds_ratio_95_ci_lower_bound=results["PTV+MIS Odds Ratio 95% CI"][0],
+        ptv_mis_odds_ratio_95_ci_upper_bound=results["PTV+MIS Odds Ratio 95% CI"][1],
         #
         flags=results["flags"],
     )

--- a/data_pipeline/pipeline_config.ini
+++ b/data_pipeline/pipeline_config.ini
@@ -110,4 +110,4 @@ local_output_root = data/output-data
 gcs_downloads_output_root = gs://exome-results-browsers-public/downloads
 local_downloads_output_root = data/downloads
 
-output_last_updated = 2026-06-17
+output_last_updated = 2026-06-24

--- a/data_pipeline/pipeline_config.ini
+++ b/data_pipeline/pipeline_config.ini
@@ -20,11 +20,11 @@ variant_annotations_path = gs://bipex-browser/200421/browser_variant_annotation_
 output_last_updated = 2022-02-07
 
 [BipEx2]
-gene_results_path = gs://bipex-browser/2026-03-22/20260322_bipex2-gene-results.ht
+gene_results_path = gs://bipex2_browser/hts/20260618_bipex2-gene-results.ht
 variant_results_path = gs://bipex-browser/2026-03-22/20260322_bipex2-case-control-counts-by-loci_strata-passing.ht
 variant_annotations_path = gs://bipex-browser/2026-03-22/bipex2-variant-annotation-table.ht
 
-output_last_updated = 2026-04-27
+output_last_updated = 2026-06-24
 
 [Epi25]
 gene_results_path = gs://epi25/year5/browser_files/202212/browser_gene_results_table.ht

--- a/src/browsers/base/Browser.tsx
+++ b/src/browsers/base/Browser.tsx
@@ -137,8 +137,8 @@ export type GeneResultColumnConfig = {
   heading?: string
   minWidth?: number
   tooltip?: string
-  render?: (record: any) => React.ReactNode
-  renderForCSV?: (record: any) => string | number
+  render?: (record: any, row?: any) => React.ReactNode
+  renderForCSV?: (record: any, row?: any) => string | number
 }
 
 export type GeneResultTabConfig = {

--- a/src/browsers/base/DownloadsPage.tsx
+++ b/src/browsers/base/DownloadsPage.tsx
@@ -16,7 +16,7 @@ const downloadUrl = (datasetId: DatasetId, file: string) => {
   if (datasetId === 'Epi25') {
     return `https://storage.googleapis.com/exome-results-browsers-public/downloads/2022-12-01/Epi25/Epi25_${file}`
   } else if (datasetId === 'BipEx2') {
-    return `https://storage.googleapis.com/exome-results-browsers-public/downloads/2026-04-14/BipEx2/BipEx2_${file}`
+    return `https://storage.googleapis.com/exome-results-browsers-public/downloads/2026-04-24/BipEx2/BipEx2_${file}`
   } else if (datasetId === 'SCHEMA2') {
     return `https://storage.googleapis.com/exome-results-browsers-public/downloads/2026-05-26/SCHEMA2/SCHEMA2_${file}`
   } else if (datasetId === 'IBD') {

--- a/src/browsers/base/GeneResultsPage/geneResultTableColumns.tsx
+++ b/src/browsers/base/GeneResultsPage/geneResultTableColumns.tsx
@@ -137,10 +137,10 @@ const getTableColumns = (geneResultColumns: GeneResultColumnConfig[]): GeneResul
     minWidth: column.minWidth || 65,
     grow: 0,
     render: column.render
-      ? (row, key) => column.render!(get(row, key))
+      ? (row, key) => column.render!(get(row, key), row)
       : (row, key) => renderFloatAsScientific({ value: (get(row, key) as InputData), zeroValue: '0' }),
     renderForCSV: column.renderForCSV
-      ? (row, key) => column.renderForCSV!(get(row, key))
+      ? (row, key) => column.renderForCSV!(get(row, key), row)
       : (row, key) => get(row, key),
   }))
 

--- a/src/browsers/base/tableCells.tsx
+++ b/src/browsers/base/tableCells.tsx
@@ -24,7 +24,7 @@ export type InputData = number | string | null | undefined
 
 export const renderOddsRatio = ({
   value,
-  precision = 3,
+  precision = 2,
 }: {
   value: InputData
   precision?: number
@@ -42,7 +42,7 @@ export const renderOddsRatio = ({
   if (Number.isNaN(floatValue)) {
     return value
   }
-  return floatValue.toPrecision(precision)
+  return floatValue.toFixed(precision)
 }
 
 export const renderStringOrFloatPvalueAsScientific = ({

--- a/src/browsers/base/tableCells.tsx
+++ b/src/browsers/base/tableCells.tsx
@@ -80,8 +80,8 @@ export const renderFloatAsScientific = ({
   decimalPlaces = 3,
 }: {
   value: InputData
-  zeroValue: string
-  decimalPlaces: number
+  zeroValue?: string
+  decimalPlaces?: number
 }) => {
   if (value === null || value === undefined) {
     return '-'

--- a/src/browsers/bipex2/BipEx2Browser.tsx
+++ b/src/browsers/bipex2/BipEx2Browser.tsx
@@ -91,6 +91,25 @@ const BipExBrowser = () => (
         minWidth: 85,
         render: (value) => renderOddsRatio({ value: value }),
       },
+      {
+        key: 'ptv_mis_odds_ratio_ci',
+        heading: 'PTV+MIS Fisher odds ratio CI',
+        tooltip: 'The 95th percentile confidence ratio lower and upper bounds, in the format: (lower, upper)',
+        minWidth: 110,
+        render: (_value, row) => {
+          const oddsRatio = renderOddsRatio({ value: row.ptv_mis_odds_ratio })
+          const shouldRenderOddsRatioCI = !['-', '∞', '0'].includes(oddsRatio.toString())
+          if (!shouldRenderOddsRatioCI) {
+            return '-'
+          }
+
+          return (
+            <span>
+              {`(${renderOddsRatio({ value: row.ptv_mis_odds_ratio_95_ci_lower_bound })} - ${renderOddsRatio({ value: row.ptv_mis_odds_ratio_95_ci_upper_bound })})`}
+            </span>
+          )
+        },
+      },
       // ---
       {
         key: 'ptv_case_carrier',
@@ -115,6 +134,25 @@ const BipExBrowser = () => (
         heading: 'PTV Fisher odds ratio',
         minWidth: 85,
         render: (value) => renderOddsRatio({ value: value }),
+      },
+      {
+        key: 'ptv_odds_ratio_ci',
+        heading: 'PTV Fisher odds ratio CI',
+        minWidth: 110,
+        tooltip: 'The 95th percentile confidence ratio lower and upper bounds, in the format: (lower, upper)',
+        render: (_value, row) => {
+          const oddsRatio = renderOddsRatio({ value: row.ptv_odds_ratio })
+          const shouldRenderOddsRatioCI = !['-', '∞', '0'].includes(oddsRatio.toString())
+          if (!shouldRenderOddsRatioCI) {
+            return '-'
+          }
+
+          return (
+            <span>
+              {`(${renderOddsRatio({ value: row.ptv_odds_ratio_95_ci_lower_bound })} - ${renderOddsRatio({ value: row.ptv_odds_ratio_95_ci_upper_bound })})`}
+            </span>
+          )
+        }
       },
       // ---
       {
@@ -141,6 +179,26 @@ const BipExBrowser = () => (
         minWidth: 85,
         render: (value) => renderOddsRatio({ value: value }),
       },
+      {
+        key: 'mis_odds_ratio_ci',
+        heading: 'MIS Fisher odds ratio CI',
+        minWidth: 110,
+        tooltip: 'The 95th percentile confidence ratio lower and upper bounds, in the format: (lower, upper)',
+        render: (_value, row) => {
+          const oddsRatio = renderOddsRatio({ value: row.mis_odds_ratio })
+          const shouldRenderOddsRatioCI = !['-', '∞', '0'].includes(oddsRatio.toString())
+          if (!shouldRenderOddsRatioCI) {
+            return '-'
+          }
+
+          return (
+            <span>
+              {`(${renderOddsRatio({ value: row.mis_odds_ratio_95_ci_lower_bound })} - ${renderOddsRatio({ value: row.mis_odds_ratio_95_ci_upper_bound })})`}
+            </span>
+          )
+
+        }
+      },
       // ---
       {
         key: 'syn_case_carrier',
@@ -166,31 +224,51 @@ const BipExBrowser = () => (
         minWidth: 85,
         render: (value) => renderOddsRatio({ value: value }),
       },
+      {
+        key: 'syn_odds_ratio_ci',
+        heading: 'SYN Fisher odds ratio CI (Lower bound - upper bound)',
+        minWidth: 110,
+        tooltip: 'The 95th percentile confidence ratio lower and upper bounds, in the format: (lower bound, upper bound)',
+        render: (_value, row) => {
+          const oddsRatio = renderOddsRatio({ value: row.syn_odds_ratio })
+          const shouldRenderOddsRatioCI = !['-', '∞', '0'].includes(oddsRatio.toString())
+          if (!shouldRenderOddsRatioCI) {
+            return '-'
+          }
+
+          return (
+            <span>
+              {`(${renderOddsRatio({ value: row.syn_odds_ratio_95_ci_lower_bound })} - ${renderOddsRatio({ value: row.syn_odds_ratio_95_ci_upper_bound })})`}
+            </span>
+          )
+        },
+      },
     ]}
     variantAnalysisGroupOptions={bipex2AnalysisGroups}
     defaultVariantAnalysisGroup={bipex2DefaultAnalysisGroup}
-    variantResultColumns={[
-      {
-        key: 'group_result.mac',
-        heading: 'MAC',
-        minWidth: 65,
-      },
-      {
-        key: 'group_result.missense_passing',
-        heading: 'Missense passing',
-        minWidth: 85,
-        render: (value) => (value ? 'yes' : ''),
-        renderForCSV: (value) => (value ? 'yes' : ''),
-      },
-      {
-        key: 'group_result.in_analysis',
-        heading: 'In analysis',
-        minWidth: 85,
-        render: (value) => (value ? 'yes' : ''),
-        renderForCSV: (value) => (value ? 'yes' : ''),
-        showOnDetails: false,
-      },
-    ]}
+    variantResultColumns={
+      [
+        {
+          key: 'group_result.mac',
+          heading: 'MAC',
+          minWidth: 65,
+        },
+        {
+          key: 'group_result.missense_passing',
+          heading: 'Missense passing',
+          minWidth: 85,
+          render: (value) => (value ? 'yes' : ''),
+          renderForCSV: (value) => (value ? 'yes' : ''),
+        },
+        {
+          key: 'group_result.in_analysis',
+          heading: 'In analysis',
+          minWidth: 85,
+          render: (value) => (value ? 'yes' : ''),
+          renderForCSV: (value) => (value ? 'yes' : ''),
+          showOnDetails: false,
+        },
+      ]}
     variantCustomFilter={{
       component: BipExVariantFilter,
       defaultFilter: {

--- a/src/browsers/bipex2/BipEx2GeneResults.tsx
+++ b/src/browsers/bipex2/BipEx2GeneResults.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import styled from 'styled-components'
 
-import { Badge, BaseTable, ExternalLink } from '@gnomad/ui'
+import { Badge, BaseTable, ExternalLink, TooltipAnchor, TooltipHint } from '@gnomad/ui'
 
 import HelpButton from '../base/HelpButton'
-import { BipEx2AnalysisGroup, bipex2PValueOfZeroPlaceholder } from './BipEx2Browser'
+import { BipEx2AnalysisGroup } from './BipEx2Browser'
 import { renderOddsRatio, renderStringOrFloatPvalueAsScientific } from '../base/tableCells'
 
 const Table = styled(BaseTable)`
@@ -13,22 +13,35 @@ const Table = styled(BaseTable)`
 enum ResultEnum {
   n_cases,
   n_controls,
+  //
   ptv_case_carrier,
   ptv_ctrl_carrier,
   ptv_p_value,
   ptv_odds_ratio,
+  ptv_odds_ratio_95_ci_lower_bound,
+  ptv_odds_ratio_95_ci_upper_bound,
+  //
   mis_case_carrier,
   mis_ctrl_carrier,
   mis_p_value,
   mis_odds_ratio,
+  mis_odds_ratio_95_ci_lower_bound,
+  mis_odds_ratio_95_ci_upper_bound,
+  //
   ptv_mis_case_carrier,
   ptv_mis_ctrl_carrier,
   ptv_mis_p_value,
   ptv_mis_odds_ratio,
+  ptv_mis_odds_ratio_95_ci_lower_bound,
+  ptv_mis_odds_ratio_95_ci_upper_bound,
+  //
   syn_case_carrier,
   syn_ctrl_carrier,
   syn_p_value,
   syn_odds_ratio,
+  syn_odds_ratio_95_ci_lower_bound,
+  syn_odds_ratio_95_ci_upper_bound,
+  //
   flags,
 }
 
@@ -72,14 +85,23 @@ const createGeneTableRow = (
   category: string,
   categoryAbbreviation: CategoryAbbreviation
 ) => {
+  const oddsRatio = renderOddsRatio({ value: object[`${categoryAbbreviation}_odds_ratio`] })
+  const oddsRatio95CILowerBound = renderOddsRatio({ value: object[`${categoryAbbreviation}_odds_ratio_95_ci_lower_bound`] })
+  const oddsRatio95CIUpperBound = renderOddsRatio({ value: object[`${categoryAbbreviation}_odds_ratio_95_ci_upper_bound`] })
+
   return (
     <tr>
       <th scope="row">{category}</th>
       <td>{safeReturnValue(object, `${categoryAbbreviation}_case_carrier`)}</td>
       <td>{safeReturnValue(object, `${categoryAbbreviation}_ctrl_carrier`)}</td>
-      <td>{safeReturnValue(object, `${categoryAbbreviation}_p_value`)}</td>
       <td>{renderStringOrFloatPvalueAsScientific({ value: object[`${categoryAbbreviation}_p_value`] })}</td>
-      <td>{renderOddsRatio({ value: object[`${categoryAbbreviation}_odds_ratio`] })}</td>
+      <td>{oddsRatio}</td>
+      <td>
+        {oddsRatio === '-' && '-'}
+        {oddsRatio !== '-' &&
+          `(${oddsRatio95CILowerBound.toString()} - ${oddsRatio95CIUpperBound})`
+        }
+      </td>
     </tr>
   )
 }
@@ -100,6 +122,11 @@ const BipExGeneResult = ({ result }: { result: ResultObject }) => (
           <th scope="col">Control Count</th>
           <th scope="col">P-value</th>
           <th scope="col">Odds Ratio</th>
+          <th scope="col">
+            <TooltipAnchor tooltip="The 95th percentile confidence ratio upper and lower bounds, in the format: (lower bound, upper bound)">
+              <TooltipHint> Odds Ratio CI</TooltipHint>
+            </TooltipAnchor>
+          </th>
         </tr>
       </thead>
       <tbody>


### PR DESCRIPTION
New handoff tables included a new array field, representing the 95% confidence interval for the odds ratio per variant category, per analysis group.

Here we ingest the new data, and use it on the frontend.