### PR TITLE
Update GP2 brower with feedback

### DIFF
--- a/src/browsers/base/GenePage/VariantDetails.tsx
+++ b/src/browsers/base/GenePage/VariantDetails.tsx
@@ -499,6 +499,23 @@ const VariantDetails = ({
       heading: 'WGS AF Other',
       render: renderExponentialIfSmall,
     },
+    // ---
+    {
+      key: 'group_result.ces_ac_pd',
+      heading: 'CES AC PD',
+      render: (value: number) => value,
+    },
+    {
+      key: 'group_result.ces_an_pd',
+      heading: 'CES AN PD',
+      render: (value: number) => value,
+    },
+    {
+      key: 'group_result.ces_af_pd',
+      heading: 'CES AF PD',
+      render: (value) => renderExponentialIfSmall(value),
+    },
+
   ]
 
   const allGP2CaseColumnGroups = Object.keys(filter.gp2VariantColumnGroups!)

--- a/src/browsers/gp2/GP2Browser.tsx
+++ b/src/browsers/gp2/GP2Browser.tsx
@@ -148,8 +148,9 @@ const GP2Browser = () => {
       variantAnalysisGroupLabels={gp2AnalysisGroupLabels}
       variantResultColumns={[]}
       variantConsequences={variantConsequences}
-      renderVariantAttributes={({ cadd, clinvar_variation_id: clinvarID, rsid }) => [
+      renderVariantAttributes={({ cadd, revel, clinvar_variation_id: clinvarID, rsid }) => [
         { label: 'CADD', content: cadd === null ? '-' : cadd },
+        { label: 'Revel', content: revel === null ? '–' : revel },
         {
           label: (
             <TooltipAnchor tooltip="ClinVar data last updated September 18, 2025">

--- a/src/browsers/gp2/content/terms.md
+++ b/src/browsers/gp2/content/terms.md
@@ -8,4 +8,4 @@ We encourage you to contact GP2 before embarking on any analyses using these dat
 
 ## Citations in publications
 
-We request that any use of data from the GP2 browser cite the consortium's paper, [_GP2: The Global Parkinson's Genetics Program_](https://doi.org/10.1002/mds.28494), and the the browser release paper: [_The Global Parkinson's Disease Genetics (GP2) Genome Browser_](https://doi.org/10.1002/mds.70309).
+We request that any use of data from the GP2 browser cite the consortium's paper, [_GP2: The Global Parkinson's Genetics Program_](https://doi.org/10.1002/mds.28494), and the the browser release paper: [_The Global Parkinson's Disease Genetics (GP2) Genome Browser_](https://doi.org/10.1002/mds.70309) with the appropriate DOI corresponding to the specific data release version utilized (see [https://zenodo.org/records/17753486](https://zenodo.org/records/17753486) for the full list of version-specific DOIs).


### PR DESCRIPTION
- Render revel score on single variant modal
- Render CES columns on single variant modal
- Include additional content on terms page in citations 