### PR TITLE
feat(schema2): add 95% CI to gene results, point at new freeze

### DIFF
--- a/data_pipeline/data_pipeline/datasets/schema2/schema2_gene_results.py
+++ b/data_pipeline/data_pipeline/datasets/schema2/schema2_gene_results.py
@@ -81,23 +81,27 @@ def prepare_gene_results(test_genes, _output_root):
         ptv_control_carrier=gene_results["PTV Control Carrier"],  # int32
         ptv_p_value=gene_results["PTV Pvalue"],  # float64
         ptv_odds_ratio=gene_results["PTV OR"],  # string
+        ptv_odds_ratio_95_ci=gene_results["PTV OR 95% CI"],  # string, e.g. "0.62 - 2.39"
         ptv_n_de_novo=gene_results["N de novo PTV"],  # int32
         #
         ptv_mis_case_carrier=gene_results["PTV + Missense Case Carrier"],  # int32
         ptv_mis_control_carrier=gene_results["PTV + Missense Control Carrier"],  # int32
         ptv_mis_p_value=gene_results["PTV + Missense Pvalue"],  # float64
         ptv_mis_odds_ratio=gene_results["PTV+ Missense OR"],  # string
+        ptv_mis_odds_ratio_95_ci=gene_results["PTV+ Missense OR 95% CI"],  # string, e.g. "0.62 - 2.39"
         ptv_mis_n_de_novo=gene_results["N de novo PTV + Missense"],  # int32
         #
         mis_case_carrier=gene_results["Missense Case Carrier"],  # int32
         mis_control_carrier=gene_results["Missense Control Carrier"],  # int32
         mis_p_value=gene_results["Missense Pvalue"],  # float64
         mis_odds_ratio=gene_results["Missense OR"],  # string
+        mis_odds_ratio_95_ci=gene_results["Missense OR 95% CI"],  # string, e.g. "0.62 - 2.39"
         #
         syn_case_carrier=gene_results["Synonymous Case Carrier"],  # int32
         syn_control_carrier=gene_results["Synonymous Control Carrier"],  # int32
         syn_p_value=gene_results["Synonymous Pvalue"],  # float64
         syn_odds_ratio=gene_results["Synonymous OR"],  # string
+        syn_odds_ratio_95_ci=gene_results["Synonymous OR 95% CI"],  # string, e.g. "0.62 - 2.39"
         #
         n_de_novo_p_value=gene_results["de novo Pvalue"],  # float64
         #

--- a/data_pipeline/pipeline_config.ini
+++ b/data_pipeline/pipeline_config.ini
@@ -42,7 +42,7 @@ output_last_updated = 2020-10-11
 
 
 [SCHEMA2]
-gene_results_path = gs://schema_jsealock/schema2_browser/dec_2025_freeze/schema2_case_control_results_05-19-2026.ht
+gene_results_path = gs://schema_jsealock/schema2_browser/dec_2025_freeze/schema2_case_control_results_07-08-2026.ht
 variant_results_path = gs://schema_jsealock/schema2_browser/dec_2025_freeze/schema2-case-control-counts-by-loci-de_novo-in-analysis-05-06-2026.ht
 variant_annotations_path = gs://schema_jsealock/schema2_browser/dec_2025_freeze/schema2-browser-variant-annotation-table-case-control-dn-repart-05-01-2026.ht
 

--- a/src/browsers/base/tableCells.tsx
+++ b/src/browsers/base/tableCells.tsx
@@ -45,6 +45,25 @@ export const renderOddsRatio = ({
   return floatValue.toFixed(precision)
 }
 
+export const renderOddsRatioCI = ({
+  oddsRatio,
+  confidenceInterval,
+}: {
+  oddsRatio: InputData
+  confidenceInterval: InputData
+}) => {
+  const renderedOddsRatio = renderOddsRatio({ value: oddsRatio })
+  if (renderedOddsRatio === '-') {
+    return '-'
+  }
+
+  if (confidenceInterval === null || confidenceInterval === undefined || confidenceInterval === '') {
+    return '-'
+  }
+
+  return `(${confidenceInterval})`
+}
+
 export const renderStringOrFloatPvalueAsScientific = ({
   value,
   zeroValue = '0',

--- a/src/browsers/bipex2/BipEx2GeneResults.tsx
+++ b/src/browsers/bipex2/BipEx2GeneResults.tsx
@@ -5,7 +5,11 @@ import { Badge, BaseTable, ExternalLink, TooltipAnchor, TooltipHint } from '@gno
 
 import HelpButton from '../base/HelpButton'
 import { BipEx2AnalysisGroup } from './BipEx2Browser'
-import { renderOddsRatio, renderStringOrFloatPvalueAsScientific } from '../base/tableCells'
+import {
+  renderOddsRatio,
+  renderOddsRatioCI,
+  renderStringOrFloatPvalueAsScientific,
+} from '../base/tableCells'
 
 const Table = styled(BaseTable)`
   min-width: 325px;
@@ -85,7 +89,7 @@ const createGeneTableRow = (
   category: string,
   categoryAbbreviation: CategoryAbbreviation
 ) => {
-  const oddsRatio = renderOddsRatio({ value: object[`${categoryAbbreviation}_odds_ratio`] })
+  const oddsRatio = object[`${categoryAbbreviation}_odds_ratio`]
   const oddsRatio95CILowerBound = renderOddsRatio({
     value: object[`${categoryAbbreviation}_odds_ratio_95_ci_lower_bound`],
   })
@@ -103,11 +107,12 @@ const createGeneTableRow = (
           value: object[`${categoryAbbreviation}_p_value`],
         })}
       </td>
-      <td>{oddsRatio}</td>
+      <td>{renderOddsRatio({ value: oddsRatio })}</td>
       <td>
-        {oddsRatio === '-' && '-'}
-        {oddsRatio !== '-' &&
-          `(${oddsRatio95CILowerBound.toString()} - ${oddsRatio95CIUpperBound})`}
+        {renderOddsRatioCI({
+          oddsRatio,
+          confidenceInterval: `${oddsRatio95CILowerBound} - ${oddsRatio95CIUpperBound}`,
+        })}
       </td>
     </tr>
   )

--- a/src/browsers/schema2/SCHEMA2GeneResults.tsx
+++ b/src/browsers/schema2/SCHEMA2GeneResults.tsx
@@ -21,24 +21,36 @@ const safeRenderCount = (value: number | null | undefined) => {
   return value
 }
 
+const renderOddsRatioCI = (ci: string | null | undefined) => {
+  if (ci === null || ci === undefined || ci === '') {
+    return '-'
+  }
+
+  return `(${ci})`
+}
+
 type SchemaGeneResult = {
   ptv_case_carrier: number
   ptv_control_carrier: number
   ptv_p_value: number
   ptv_odds_ratio: string
+  ptv_odds_ratio_95_ci: string
 
   ptv_mis_case_carrier: number
   ptv_mis_control_carrier: number
   ptv_mis_p_value: number
   ptv_mis_odds_ratio: string
+  ptv_mis_odds_ratio_95_ci: string
 
   mis_case_carrier: number
   mis_control_carrier: number
   mis_odds_ratio: string
+  mis_odds_ratio_95_ci: string
 
   syn_case_carrier: number
   syn_control_carrier: number
   syn_odds_ratio: string
+  syn_odds_ratio_95_ci: string
 
   ptv_n_de_novo: number
   ptv_mis_n_de_novo: number
@@ -70,6 +82,11 @@ const SCHEMAGeneResult = ({ result }: SchemaGeneResultProps) => {
               Odds Ratio
             </th>
             <th scope="col" style={{ paddingLeft: '10px' }}>
+              <TooltipAnchor tooltip="The odds ratio 95% confidence interval lower and upper bounds in the format: (lower bound - upper bound)">
+                <TooltipHint>Odds Ratio CI</TooltipHint>
+              </TooltipAnchor>
+            </th>
+            <th scope="col" style={{ paddingLeft: '10px' }}>
               Case/Control <span style={{ fontStyle: 'italic' }}>P</span>-value
             </th>
             <th scope="col" style={{ paddingLeft: '10px', borderLeft: '1px solid #ccc' }}>
@@ -97,6 +114,9 @@ const SCHEMAGeneResult = ({ result }: SchemaGeneResultProps) => {
               {renderOddsRatio({ value: result.ptv_odds_ratio })}
             </td>
             <td style={{ paddingLeft: '10px' }}>
+              {renderOddsRatioCI(result.ptv_odds_ratio_95_ci)}
+            </td>
+            <td style={{ paddingLeft: '10px' }}>
               {renderStringOrFloatPvalueAsScientific({ value: result.ptv_p_value })}
             </td>
             <td style={{ paddingLeft: '10px', borderLeft: '1px solid #ccc' }}>
@@ -121,6 +141,9 @@ const SCHEMAGeneResult = ({ result }: SchemaGeneResultProps) => {
               {renderOddsRatio({ value: result.ptv_mis_odds_ratio })}
             </td>
             <td style={{ paddingLeft: '10px' }}>
+              {renderOddsRatioCI(result.ptv_mis_odds_ratio_95_ci)}
+            </td>
+            <td style={{ paddingLeft: '10px' }}>
               {renderStringOrFloatPvalueAsScientific({ value: result.ptv_mis_p_value })}
             </td>
             <td style={{ paddingLeft: '10px', borderLeft: '1px solid #ccc' }}>
@@ -141,6 +164,9 @@ const SCHEMAGeneResult = ({ result }: SchemaGeneResultProps) => {
             <td style={{ paddingLeft: '10px' }}>
               {renderOddsRatio({ value: result.mis_odds_ratio })}
             </td>
+            <td style={{ paddingLeft: '10px' }}>
+              {renderOddsRatioCI(result.mis_odds_ratio_95_ci)}
+            </td>
             <td style={{ paddingLeft: '10px' }}>-</td>
             <td style={{ paddingLeft: '10px', borderLeft: '1px solid #ccc' }}>-</td>
             <td style={{ paddingLeft: '10px' }}>-</td>
@@ -158,6 +184,9 @@ const SCHEMAGeneResult = ({ result }: SchemaGeneResultProps) => {
             <td>{safeRenderCount(result.syn_control_carrier)}</td>
             <td style={{ paddingLeft: '10px' }}>
               {renderOddsRatio({ value: result.syn_odds_ratio })}
+            </td>
+            <td style={{ paddingLeft: '10px' }}>
+              {renderOddsRatioCI(result.syn_odds_ratio_95_ci)}
             </td>
             <td style={{ paddingLeft: '10px' }}>-</td>
             <td style={{ paddingLeft: '10px', borderLeft: '1px solid #ccc' }}>-</td>

--- a/src/browsers/schema2/SCHEMA2GeneResults.tsx
+++ b/src/browsers/schema2/SCHEMA2GeneResults.tsx
@@ -6,7 +6,11 @@ import { BaseTable, TooltipAnchor, TooltipHint } from '@gnomad/ui'
 import HelpButton from '../base/HelpButton'
 import StyledContent from '../base/StyledContent'
 import geneResultsDescription from './content/generesults.md'
-import { renderOddsRatio, renderStringOrFloatPvalueAsScientific } from '../base/tableCells'
+import {
+  renderOddsRatio,
+  renderOddsRatioCI,
+  renderStringOrFloatPvalueAsScientific,
+} from '../base/tableCells'
 import { SCHEMA2AnalysisGroup } from './SCHEMA2Browser'
 
 const Table = styled(BaseTable)`
@@ -19,14 +23,6 @@ const safeRenderCount = (value: number | null | undefined) => {
   }
 
   return value
-}
-
-const renderOddsRatioCI = (ci: string | null | undefined) => {
-  if (ci === null || ci === undefined || ci === '') {
-    return '-'
-  }
-
-  return `(${ci})`
 }
 
 type SchemaGeneResult = {
@@ -114,7 +110,10 @@ const SCHEMAGeneResult = ({ result }: SchemaGeneResultProps) => {
               {renderOddsRatio({ value: result.ptv_odds_ratio })}
             </td>
             <td style={{ paddingLeft: '10px' }}>
-              {renderOddsRatioCI(result.ptv_odds_ratio_95_ci)}
+              {renderOddsRatioCI({
+                oddsRatio: result.ptv_odds_ratio,
+                confidenceInterval: result.ptv_odds_ratio_95_ci,
+              })}
             </td>
             <td style={{ paddingLeft: '10px' }}>
               {renderStringOrFloatPvalueAsScientific({ value: result.ptv_p_value })}
@@ -141,7 +140,10 @@ const SCHEMAGeneResult = ({ result }: SchemaGeneResultProps) => {
               {renderOddsRatio({ value: result.ptv_mis_odds_ratio })}
             </td>
             <td style={{ paddingLeft: '10px' }}>
-              {renderOddsRatioCI(result.ptv_mis_odds_ratio_95_ci)}
+              {renderOddsRatioCI({
+                oddsRatio: result.ptv_mis_odds_ratio,
+                confidenceInterval: result.ptv_mis_odds_ratio_95_ci,
+              })}
             </td>
             <td style={{ paddingLeft: '10px' }}>
               {renderStringOrFloatPvalueAsScientific({ value: result.ptv_mis_p_value })}
@@ -165,7 +167,10 @@ const SCHEMAGeneResult = ({ result }: SchemaGeneResultProps) => {
               {renderOddsRatio({ value: result.mis_odds_ratio })}
             </td>
             <td style={{ paddingLeft: '10px' }}>
-              {renderOddsRatioCI(result.mis_odds_ratio_95_ci)}
+              {renderOddsRatioCI({
+                oddsRatio: result.mis_odds_ratio,
+                confidenceInterval: result.mis_odds_ratio_95_ci,
+              })}
             </td>
             <td style={{ paddingLeft: '10px' }}>-</td>
             <td style={{ paddingLeft: '10px', borderLeft: '1px solid #ccc' }}>-</td>
@@ -186,7 +191,10 @@ const SCHEMAGeneResult = ({ result }: SchemaGeneResultProps) => {
               {renderOddsRatio({ value: result.syn_odds_ratio })}
             </td>
             <td style={{ paddingLeft: '10px' }}>
-              {renderOddsRatioCI(result.syn_odds_ratio_95_ci)}
+              {renderOddsRatioCI({
+                oddsRatio: result.syn_odds_ratio,
+                confidenceInterval: result.syn_odds_ratio_95_ci,
+              })}
             </td>
             <td style={{ paddingLeft: '10px' }}>-</td>
             <td style={{ paddingLeft: '10px', borderLeft: '1px solid #ccc' }}>-</td>

--- a/src/browsers/schema2/SCHEMA2GeneResults.tsx
+++ b/src/browsers/schema2/SCHEMA2GeneResults.tsx
@@ -40,11 +40,13 @@ type SchemaGeneResult = {
 
   mis_case_carrier: number
   mis_control_carrier: number
+  mis_p_value: number
   mis_odds_ratio: string
   mis_odds_ratio_95_ci: string
 
   syn_case_carrier: number
   syn_control_carrier: number
+  syn_p_value: number
   syn_odds_ratio: string
   syn_odds_ratio_95_ci: string
 
@@ -172,7 +174,9 @@ const SCHEMAGeneResult = ({ result }: SchemaGeneResultProps) => {
                 confidenceInterval: result.mis_odds_ratio_95_ci,
               })}
             </td>
-            <td style={{ paddingLeft: '10px' }}>-</td>
+            <td style={{ paddingLeft: '10px' }}>
+              {renderStringOrFloatPvalueAsScientific({ value: result.mis_p_value })}
+            </td>
             <td style={{ paddingLeft: '10px', borderLeft: '1px solid #ccc' }}>-</td>
             <td style={{ paddingLeft: '10px' }}>-</td>
           </tr>
@@ -196,7 +200,9 @@ const SCHEMAGeneResult = ({ result }: SchemaGeneResultProps) => {
                 confidenceInterval: result.syn_odds_ratio_95_ci,
               })}
             </td>
-            <td style={{ paddingLeft: '10px' }}>-</td>
+            <td style={{ paddingLeft: '10px' }}>
+              {renderStringOrFloatPvalueAsScientific({ value: result.syn_p_value })}
+            </td>
             <td style={{ paddingLeft: '10px', borderLeft: '1px solid #ccc' }}>-</td>
             <td style={{ paddingLeft: '10px' }}>-</td>
           </tr>


### PR DESCRIPTION
Mirrors the BipEx2 results tab by displaying the odds ratio 95% confidence interval alongside each odds ratio, and updates the gene results source to Riley's 07-08-2026 freeze.