### PR TITLE
Add basic smoketest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,8 @@ hail-*.log
 
 # dev data
 /data
+
+# Playwright
+/test-results
+/playwright-report
+/blob-report

--- a/e2e/gene-page.spec.ts
+++ b/e2e/gene-page.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from '@playwright/test'
+
+interface GeneFixture {
+  id: string
+  symbol: string
+}
+
+const PCSK9: GeneFixture = { id: 'ENSG00000169174', symbol: 'PCSK9' }
+const NOD2: GeneFixture = { id: 'ENSG00000167207', symbol: 'NOD2' }
+
+const DEFAULT_GENE = PCSK9
+const DATASET_GENE_OVERRIDES: Partial<Record<string, GeneFixture>> = {
+  IBD: NOD2,
+}
+
+const DEMO_PASSWORD = process.env.DEMO_PASSWORD?.replace(/^"|"$/g, '') || 'password'
+
+test.beforeEach(async ({ page }, testInfo) => {
+  if (testInfo.project.name === 'BipEx2') {
+    await page.request.post('/api/auth', { data: { password: DEMO_PASSWORD } })
+  }
+})
+
+test('renders the gene page and opens the variant modal', async ({ page }, testInfo) => {
+  const gene = DATASET_GENE_OVERRIDES[testInfo.project.name] ?? DEFAULT_GENE
+
+  const pageErrors: string[] = []
+  page.on('pageerror', (error) => pageErrors.push(error.message))
+
+  await page.goto(`/gene/${gene.id}`)
+  await expect(page.locator('h1')).toContainText(gene.symbol)
+
+  const variantButton = page.getByRole('button', { name: /^\S+-\d+-\S+-\S+$/ }).first()
+  const variantId = await variantButton.textContent()
+  await variantButton.click()
+
+  const modal = page.locator('#variant-details-modal')
+  await expect(modal).toBeVisible()
+  await expect(modal).toContainText(variantId!)
+
+  expect(pageErrors, `uncaught page error(s): ${pageErrors.join('; ')}`).toEqual([])
+})

--- a/e2e/gene-results-page.spec.ts
+++ b/e2e/gene-results-page.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from '@playwright/test'
+
+const DEMO_PASSWORD = process.env.DEMO_PASSWORD?.replace(/^"|"$/g, '') || 'password'
+
+test.beforeEach(async ({ page }, testInfo) => {
+  if (testInfo.project.name === 'BipEx2') {
+    await page.request.post('/api/auth', { data: { password: DEMO_PASSWORD } })
+  }
+})
+
+test('renders the gene results table', async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name === 'GP2', 'GP2 has no gene results page')
+
+  const pageErrors: string[] = []
+  page.on('pageerror', (error) => pageErrors.push(error.message))
+
+  await page.goto('/results')
+  await expect(page.locator('h1')).toBeVisible()
+
+  await expect(page.getByRole('gridcell', { name: 'PCSK9' }).first()).toBeVisible()
+
+  expect(pageErrors, `uncaught page error(s): ${pageErrors.join('; ')}`).toEqual([])
+})

--- a/package.json
+++ b/package.json
@@ -13,7 +13,10 @@
     "lint:js": "eslint .",
     "lint:css": "stylelint 'src/**/*.js'",
     "typecheck": "yarn tsc --noEmit",
-    "typecheck:watch": "yarn tsc -w --noEmit"
+    "typecheck:watch": "yarn tsc -w --noEmit",
+    "smoketest:complete": "./scripts/smoke.sh",
+    "smoketest:pipeline": "./scripts/smoke-pipeline.sh",
+    "smoketest:frontend": "playwright test"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@babel/preset-react": "^7.9.4",
     "@gnomad/markdown-loader": "^1.0.0",
     "@hot-loader/react-dom": "^16.11.0",
+    "@playwright/test": "1.44.0",
     "@types/compression": "^1.8.1",
     "@types/express": "^5.0.6",
     "@types/gtag.js": "^0.0.20",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig } from '@playwright/test'
+
+const BROWSERS = ['ASC', 'BipEx', 'BipEx2', 'Epi25', 'SCHEMA', 'IBD', 'GP2'] as const
+
+const BASE_PORT = 8101
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  reporter: 'list',
+
+  webServer: BROWSERS.map((browser, i) => ({
+    command: 'node_modules/.bin/ts-node src/server/server.ts',
+    url: `http://localhost:${BASE_PORT + i}/ready`,
+    reuseExistingServer: !process.env.CI,
+    env: {
+      ...process.env,
+      NODE_ENV: 'development',
+      BROWSER: browser,
+      RESULTS_DATA_DIRECTORY: 'data/smoke',
+      PORT: String(BASE_PORT + i),
+    },
+  })),
+
+  projects: BROWSERS.map((browser, i) => ({
+    name: browser,
+    use: { baseURL: `http://localhost:${BASE_PORT + i}` },
+  })),
+})

--- a/scripts/smoke-pipeline.sh
+++ b/scripts/smoke-pipeline.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+#
+# Usage:
+#   ./scripts/smoke-pipeline.sh
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+if [ ! -d .venv ]; then
+  echo "error: .venv does not exist. Run 'uv sync --group dev' (see CONTRIBUTING.md) first." >&2
+  exit 1
+fi
+
+UV_RUN=(uv run --no-sync)
+
+PCSK9_GENE_ID=ENSG00000169174
+IBD_GENE_ID=ENSG00000167207
+SMOKE_GENES=("$PCSK9_GENE_ID" "$IBD_GENE_ID")
+DATASETS=(ASC BipEx BipEx2 Epi25 SCHEMA IBD GP2 ClinVarGRCh38)
+SMOKE_DIR=data/smoke
+
+echo "==> prepare_gene_models"
+"${UV_RUN[@]}" ./data_pipeline/run_pipeline.py --environment local prepare_gene_models --output-local
+
+echo "==> prepare_datasets (${DATASETS[*]})"
+"${UV_RUN[@]}" ./data_pipeline/run_pipeline.py --environment local prepare_datasets \
+  --datasets "${DATASETS[@]}" --output-local --test-genes
+
+echo "==> combine_datasets (${DATASETS[*]})"
+"${UV_RUN[@]}" ./data_pipeline/run_pipeline.py --environment local combine_datasets \
+  --datasets "${DATASETS[@]}" --output-local
+
+combined_date=$("${UV_RUN[@]}" python3 -c "
+import configparser
+config = configparser.ConfigParser()
+config.read('data_pipeline/pipeline_config.ini')
+print(config.get('output', 'output_last_updated'))
+")
+combined_ht="data/output-data/combined/${combined_date}/combined.ht"
+
+if [ ! -d "$combined_ht" ]; then
+  echo "error: expected combine_datasets to write $combined_ht, but it does not exist" >&2
+  exit 1
+fi
+
+echo "==> write_results_files -> $SMOKE_DIR"
+rm -rf "$SMOKE_DIR"
+"${UV_RUN[@]}" ./data_pipeline/write_results_files.py "$combined_ht" "$SMOKE_DIR" --genes "${SMOKE_GENES[@]}"
+
+echo "Wrote smoke test data to $SMOKE_DIR"

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -34,7 +34,7 @@ echo "==> Building browsers"
 yarn run build
 
 if [ "${#args[@]}" -eq 0 ]; then
-  yarn run smoke:frontend
+  yarn run smoketest:frontend
 else
-  yarn run smoke:frontend "${args[@]}"
+  yarn run smoketest:frontend "${args[@]}"
 fi

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# Usage:
+#   ./scripts/smoke.sh
+#   ./scripts/smoke.sh --clean-install     # clear and re-sync dependencies
+#   ./scripts/smoke.sh --project=SCHEMA    # only playwright test a certain dataset
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+clean_install=false
+args=()
+for arg in "$@"; do
+  case "$arg" in
+    --clean-install) clean_install=true ;;
+    *) args+=("$arg") ;;
+  esac
+done
+
+if [ "$clean_install" = true ]; then
+  echo "==> Clean install: node_modules"
+  rm -rf node_modules
+  yarn install --frozen-lockfile --non-interactive --no-progress
+
+  echo "==> Clean install: .venv"
+  rm -rf .venv
+  uv sync --locked --group dev
+  echo "Re-run .llm_nb/install-gcs-connector.py now if the pipeline fails to read gs:// paths."
+fi
+
+./scripts/smoke-pipeline.sh
+
+echo "==> Building browsers"
+yarn run build
+
+if [ "${#args[@]}" -eq 0 ]; then
+  yarn run smoke:frontend
+else
+  yarn run smoke:frontend "${args[@]}"
+fi

--- a/yarn.lock
+++ b/yarn.lock
@@ -1281,6 +1281,13 @@
   dependencies:
     mkdirp "^1.0.4"
 
+"@playwright/test@1.44.0":
+  version "1.44.0"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.44.0.tgz#ac7a764b5ee6a80558bdc0fcbc525fcb81f83465"
+  integrity sha512-rNX5lbNidamSUorBhB4XZ9SQTjAqfe5M+p37Z8ic0jPFBMo5iCtQz1kRWkEMg+rYOKSlVycpQmpqjSFq7LXOfg==
+  dependencies:
+    playwright "1.44.0"
+
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
@@ -4353,6 +4360,11 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
+fsevents@2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
+
 fsevents@^1.2.7:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.13.tgz#f325cb0455592428bcf11b383370ef70e3bfcc38"
@@ -6855,6 +6867,20 @@ pkg-dir@^4.1.0:
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
   dependencies:
     find-up "^4.0.0"
+
+playwright-core@1.44.0:
+  version "1.44.0"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.44.0.tgz#316c4f0bca0551ffb88b6eb1c97bc0d2d861b0d5"
+  integrity sha512-ZTbkNpFfYcGWohvTTl+xewITm7EOuqIqex0c7dNZ+aXsbrLj0qI8XlGKfPpipjm0Wny/4Lt4CJsWJk1stVS5qQ==
+
+playwright@1.44.0:
+  version "1.44.0"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.44.0.tgz#22894e9b69087f6beb639249323d80fe2b5087ff"
+  integrity sha512-F9b3GUCLQ3Nffrfb6dunPOkE5Mh68tR7zN32L4jCk4FjQamgesGay7/dAAe1WaMEGV04DkdJfcJzjoCKygUaRQ==
+  dependencies:
+    playwright-core "1.44.0"
+  optionalDependencies:
+    fsevents "2.3.2"
 
 polished@^3.2.0:
   version "3.6.5"


### PR DESCRIPTION
Adds basic smoketests in the form of convenience shell scripts to run all of the datasets pipeline in test mode with output local, and then playwright tests to use these datasets locally and do a basic navigation to single gene page with a click on a variant modal, and a navigate to the gene page.

Not meant to catch regressions in functionality, nor run in CI right now. More meant as a way to run a script and have confidence that changes in tooling (major/minor version updates and package manager swaps) still result in a pipeline that successfully, and a frontend that can build and serve data of the expected shape.

The intended use is to merge this, then use this when bumping node/updating node's package manager to pnpm, to have a bit more automated confidence for the second half of the toolchain updates, as opposed to running things by hand.